### PR TITLE
Add simple Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,13 @@
+# Makefile for IDE integration
+# To build without CUDA support, use:
+# make COMMAND=bin-without-cuda
+
+COMMAND?=bin
+all:
+	./makeunx $(COMMAND)
+	./makeunx install
+debug:
+	./makeunx $(COMMAND) -g
+	./makeunx install
+clean:
+	./makeunx clean


### PR DESCRIPTION
This is a simple Makefile, for easier debugging and IDE integration. It assumes #13 will get merged.

Please accredit Ortis for #11.

This Makefile does not replace `makeunx`. If you want to, look at 74d6b7c92dac5f38305d4f704846cd216ed88f03 by Ortis.