### PR TITLE
Headless Miner Changes - Predicate to v2.2

### DIFF
--- a/src/_init/gomochi
+++ b/src/_init/gomochi
@@ -105,7 +105,7 @@ cp ../genblock.bc bc/b0000000000000000.bc
 cp ../tfile.dat .
 touch mq.lck
 #../mochimo -x345678 -e -l -t1 -d  $2 $3 $4 $5 $6 $7 $8 $9
-../mochimo -x345678 -e -p2095 -q4 -l -t3 -F -f -cstartnodes.lst $2 $3 $4 $5 $6 $7 $8 $9
+../mochimo -x345678 -e -p2095 -q4 -l -t3 -F -f -P -cstartnodes.lst $2 $3 $4 $5 $6 $7 $8 $9
 if test $? -eq 0
 then
    echo Resume paused system with ./resume

--- a/src/_init/resume
+++ b/src/_init/resume
@@ -32,7 +32,7 @@ while true
 do
 echo leave files in place
 #../mochimo -x345678 -e -l -t1 -d  $2 $3 $4 $5 $6 $7 $8 $9
-../mochimo -x345678 -e  -p2095 -q4 -l -t3 -F -f -cstartnodes.lst $2 $3 $4 $5 $6 $7 $8 $9
+../mochimo -x345678 -e  -p2095 -q4 -l -t3 -F -f -P -cstartnodes.lst $2 $3 $4 $5 $6 $7 $8 $9
 if test $? -eq 0
 then
    echo Resume paused system with ./resume

--- a/src/config.h
+++ b/src/config.h
@@ -60,7 +60,7 @@
 #define MAXQUORUM     8        /* for get_eon() gang[] */
 
 #define BCONFREQ 10    /* Run con at least */
-
+#define CBITS         0        /* 8 capability bits for TX */
 #define DTRIGGER31 17185  /* for v2.0 new set_difficulty() */
 #define WTRIGGER31 17185  /* for v2.0 new add_weight() */
 #define RTRIGGER31 17185  /* for v2.0 new get_mreward() */

--- a/src/data.c
+++ b/src/data.c
@@ -68,6 +68,9 @@ int Quorum = 4;         /* Number of peers in get_eon() gang[MAXQUORUM] */
 byte Ininit;            /* non-zero when init() runs */
 byte Safemode;          /* Safe mode enable */
 byte Betabait;          /* betabait() display */
+byte Cbits = CBITS;     /* 8 capability bits */
+time_t Pushtime;        /* time of last OP_MBLOCK */
+byte Allowpush;         /* set by -P flag in mochimo.c */
 
 #endif  /* !EXCLUDE_NODES Nodes[] and ip data */
 

--- a/src/gettx.c
+++ b/src/gettx.c
@@ -41,7 +41,8 @@ int sendtx(NODE *np)
    time_t timeout;
    byte *buff;
 
-   put16(np->tx.version, PVERSION);
+   np->tx.version[0] = PVERSION;
+   np->tx.version[1] = Cbits;
    put16(np->tx.network, TXNETWORK);
    put16(np->tx.trailer, TXEOT);
 
@@ -307,6 +308,11 @@ int gettx(NODE *np, SOCKET sd)
    } else if(opcode == OP_RESOLVE) {
       tag_resolve(np);
       return 1;
+   } else if(opcode == OP_GET_CBLOCK) {
+      if(!Allowpush || !exists("miner.tmp")) return 1;
+   } else if(opcode == OP_MBLOCK) {
+      if(!Allowpush || (time(NULL) - Pushtime) < 150) return 1;
+      Pushtime = time(NULL);
    }
 
    if(opcode == OP_BUSY || opcode == OP_NACK || opcode == OP_HELLO_ACK)

--- a/src/mochimo.c
+++ b/src/mochimo.c
@@ -71,6 +71,7 @@ void usage(void)
           "         -f         frisky mode (promiscuous mirroring)\n"
           "         -S         Safe mode\n"
           "         -F         Filter private IP's\n"  /* v.28 */
+          "         -P         Allow pushed mblocks\n"
    );
    exit(0);
 }
@@ -137,6 +138,8 @@ int main(int argc, char **argv)
          case 'S':  Safemode = 1;
                     break;
          case 'F':  Noprivate = 1;  /* v.28 */
+                    break;
+         case 'P':  Allowpush = 1;  Cbits |= C_PUSH;
                     break;
          case 'x':  if(strlen(argv[j]) != 8) break;
                     Statusarg = argv[j];

--- a/src/rand.c
+++ b/src/rand.c
@@ -47,7 +47,7 @@ void getrand2(word32 *x, word32 *y, word32 *z)
 {
    *x = Lseed2;
    *y = Lseed3;
-   *y = Lseed4;
+   *z = Lseed4;
 }
 
 /* Period: 2**32 randl4() -- returns 0-65535 */

--- a/src/types.h
+++ b/src/types.h
@@ -24,7 +24,9 @@
 #define OP_BALANCE        12
 #define OP_SEND_BAL       13
 #define OP_RESOLVE        14
-#define LAST_OP           14  /* edit when adding  OP's */
+#define OP_GET_CBLOCK     15
+#define OP_MBLOCK         16
+#define LAST_OP           16  /* edit when adding  OP's */
 
 #define TXNETWORK 0x0539
 #define TXEOT     0xabcd
@@ -53,13 +55,15 @@
   Change RPLISTLEN value to make the above #if true
 #endif
 
+/* Capability bits */
+#define C_PUSH    1
 
 /* Multi-byte numbers are little-endian.
  * Structure is checked on start-up for byte-alignment.
  * HASHLEN is checked to be 32.
  */
 typedef struct {
-   byte version[2];  /* 0x02, 0x00 PVERSION  */
+   byte version[2];  /* { PVERSION, Cbits }  */
    byte network[2];  /* 0x39, 0x05 TXNETWORK */
    byte id1[2];
    byte id2[2];


### PR DESCRIPTION
The attached changes add in OP Codes 15 and 16 to the server code and request handling for the same.  These changes allow a Headless Miner to pull down a candidate block to mine, mine said block, and then push the block back to the network.  This is the first instance of a data-push in the Mochimo protocol, and allows miners without Public IPs and open port 2095, to participate in the mining of the currency.  This change is fully backward compatible with the network, and is not a mandatory upgrade.  Note: there are NO mandatory upgrades from this point forward.