### PR TITLE
Removed duplicate work increasing efficiency

### DIFF
--- a/src/trigg/cuda_trigg.cu
+++ b/src/trigg/cuda_trigg.cu
@@ -258,309 +258,403 @@ __global__ void trigg(uint32_t threads, int *g_found, uint8_t *g_seed)
    uint8_t seed[16] = {0};
    uint32_t input[16], state[8];
 
-   if(thread < 86016) {
+   if (thread <= threads) {
       /* Frame 1 -> Split 6 ways */
-      /* Consistant values */
-      seed[ 2] = 1;
-      seed[ 3] = 5;
-      seed[ 5] = 1;
-      /* Inconsistant seed values */
       if(thread < 32768) { /* Total Permutations, this frame: 32,768 ( 1 << 15 ) */
          seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
          seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
+         seed[ 5] = 1;
          seed[ 6] = Z_ING[(thread >> 11) & 15]; // 2^4
       } else
       if(thread < 49152) { /* Total Permutations, this frame: 16,384 ( 1 << 14 ) */
          seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
          seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
+         seed[ 5] = 1;
          seed[ 6] = Z_ING[(thread >> 10) & 15]; // 2^4
       } else
       if(thread < 65536) { /* Total Permutations, this frame: 16,384 ( 1 << 14 ) */
          seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
          seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
-         seed[ 6] = Y_ING[(thread >> 11) & 7];  // 2^3
+         seed[ 5] = 1;
+         seed[ 6] = Y_ING[(thread >> 11) & 7]; // 2^3
       } else
       if(thread < 73728) { /* Total Permutations, this frame: 8,192 ( 1 << 13 ) */
          seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
          seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
-         seed[ 6] = Y_ING[(thread >> 10) & 7];  // 2^3
+         seed[ 5] = 1;
+         seed[ 6] = Y_ING[(thread >> 10) & 7]; // 2^3
       } else
       if(thread < 81920) { /* Total Permutations, this frame: 16,384 ( 1 << 13 ) */
          seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
          seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
-         seed[ 6] = X_ING[(thread >> 11) & 3];  // 2^2
+         seed[ 5] = 1;
+         seed[ 6] = X_ING[(thread >> 11) & 3]; // 2^2
       } else
       if(thread < 86016) { /* Total Permutations, this frame: 8,192 ( 1 << 12 ) */
          seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
          seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 2] = 1;
+         seed[ 3] = 5;
          seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
+         seed[ 5] = 1;
          seed[ 6] = X_ING[(thread >> 10) & 3];  // 2^2
-      }
+      } else
       /* END Frame 1 */
-   } else if(thread < 200704) {
       /* Frame 2 -> Split 3 ways */
-      /* Consistant values */
-      seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
-      seed[ 2] = 1;
-      seed[ 4] = 9;
-      seed[ 5] = 2;
-      seed[ 6] = 1;
-      /* Inconsistant seed values */
       if(thread <= 151552) { /* Total Permutations, this frame: 65,536 (1 << 16) */
+         seed[ 0] = Z_TIME[(thread & 15)];      // 2^4
          seed[ 1] = Y_MASS[(thread >> 4) & 15]; // 2^4
+         seed[ 2] = 1;
          seed[ 3] = Z_INF[(thread >> 8) & 15];  // 2^4
+         seed[ 4] = 9;
+         seed[ 5] = 2;
+         seed[ 6] = 1;
          seed[ 7] = Z_AMB[(thread >> 12) & 15]; // 2^4
       } else
       if(thread <= 184320) { /* Total Permutations, this frame: 32,768 (1 << 15) */
+         seed[ 0] = Z_TIME[(thread & 15)];      // 2^4
          seed[ 1] = X_MASS[(thread >> 3) & 7];  // 2^3
+         seed[ 2] = 1;
          seed[ 3] = Z_INF[(thread >> 7) & 15];  // 2^4
+         seed[ 4] = 9;
+         seed[ 5] = 2;
+         seed[ 6] = 1;
          seed[ 7] = Z_AMB[(thread >> 11) & 15]; // 2^4
       } else
       if(thread <= 200704) { /* Total Permutations, this frame: 16,384 (1 << 14) */
+         seed[ 0] = Z_TIME[(thread & 15)];      // 2^4
          seed[ 1] = Z_MASS[(thread >> 2) & 3];  // 2^2
+         seed[ 2] = 1;
          seed[ 3] = Z_INF[(thread >> 6) & 15];  // 2^4
+         seed[ 4] = 9;
+         seed[ 5] = 2;
+         seed[ 6] = 1;
          seed[ 7] = Z_AMB[(thread >> 10) & 15]; // 2^4
-      }
+      } else
       /* END Frame 2 */
-   } else if(thread < 3346432) {
       /* Frame 3 -> Split 2 ways */
-      /* Consistant values */
-      seed[ 2] = 1;
-      seed[ 5] = 1;
-      /* Inconsistant seed values */
       if(thread < 2297856) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 )*/
          seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
          seed[ 1] = Z_TIMED[(thread >> 2) & 7];    // 2^3
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 3346432) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 )*/
          seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
          seed[ 1] = Z_TIMED[(thread >> 1) & 7];    // 2^3
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
-      }
+      } else
       /* END Frame 3 */
-   } else if(thread < 8851456) {
       /* Frame 4 -> Split 6 ways */
-      /* Consistant values */
-      seed[ 0] = 5;
-      seed[ 1] = Z_NS[(thread & 63)];              // 2^6
-      seed[ 2] = 1;
-      seed[ 6] = 3;
-      seed[ 7] = 1;
-      /* Inconsistant seed values */
       if(thread < 5443584) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
          seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
          seed[ 5] = Z_MASS[(thread >> 11) & 15];   // 2^4
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 15) & 63];    // 2^6
       } else
       if(thread < 6492160) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
          seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
          seed[ 5] = Z_MASS[(thread >> 10) & 15];   // 2^4
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 14) & 63];    // 2^6
       } else
       if(thread < 7540736) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
          seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
          seed[ 5] = Y_MASS[(thread >> 11) & 7];    // 2^3
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 14) & 63];    // 2^6
       } else
       if(thread < 8065024) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
          seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
          seed[ 5] = Y_MASS[(thread >> 10) & 7];    // 2^3
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 13) & 63];    // 2^6
       } else
       if(thread < 8589312) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
          seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
          seed[ 5] = X_MASS[(thread >> 11) & 3];    // 2^2
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 13) & 63];    // 2^6
       } else
       if(thread < 8851456) { /* Total Permutations, this frame: 262,144 ( 1 << 18 ) */
+         seed[ 0] = 5;
+         seed[ 1] = Z_NS[(thread & 63)];           // 2^6
+         seed[ 2] = 1;
          seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
          seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
          seed[ 5] = X_MASS[(thread >> 10) & 3];    // 2^2
+         seed[ 6] = 3;
+         seed[ 7] = 1;
          seed[ 8] = Z_ADJ[(thread >> 12) & 63];    // 2^6
-      }
+      } else
       /* END Frame 4 */
-   } else if(thread < 19861504) {
       /* Frame 5 -> Split 6 ways */
-      /* Consistant values */
-      seed[ 3] = 1;
-      seed[ 5] = 1;
-      /* Inconsistant seed values */
       if(thread < 13045760) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
          seed[ 0] = Z_PREP[thread & 3];            // 2^2
          seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
          seed[ 2] = Z_MASS[(thread >> 8) & 15];    // 2^4
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 12) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 17) & 31]; // 2^5
       } else
       if(thread < 15142912) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
          seed[ 0] = Y_PREP[thread & 1];            // 2^1
          seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
          seed[ 2] = Z_MASS[(thread >> 7) & 15];    // 2^4
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 17240064) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
          seed[ 0] = Z_PREP[thread & 3];            // 2^2
          seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
          seed[ 2] = Y_MASS[(thread >> 8) & 7];     // 2^3
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 18288640) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
          seed[ 0] = Y_PREP[thread & 1];            // 2^1
          seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
          seed[ 2] = Y_MASS[(thread >> 7) & 7];     // 2^3
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
       } else
       if(thread < 19337216) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
          seed[ 0] = Z_PREP[thread & 3];            // 2^2
          seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
          seed[ 2] = X_MASS[(thread >> 8) & 3];     // 2^2
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
       } else
       if(thread < 19861504) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
          seed[ 0] = Y_PREP[thread & 1];            // 2^1
          seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
          seed[ 2] = X_MASS[(thread >> 7) & 3];     // 2^2
+         seed[ 3] = 1;
          seed[ 4] = Z_NPL[(thread >> 9) & 31];     // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 14) & 31]; // 2^5
-      }
+      } else
       /* END Frame 5 */
-   } else if(thread < 30871552) {
       /* Frame 6 -> Split 6 ways */
-      /* Consistant values */
-      seed[ 2] = 1;
-      seed[ 5] = 1;
-      /* Inconsistant seed values */
       if(thread < 24055808) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
          seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
          seed[ 1] = Z_MASS[(thread >> 2) & 15];    // 2^4
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 6) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 12) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 17) & 31]; // 2^5
       } else
       if(thread < 26152960) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
          seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
          seed[ 1] = Z_MASS[(thread >> 1) & 15];    // 2^4
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 28250112) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
          seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
          seed[ 1] = Y_MASS[(thread >> 2) & 7];     // 2^3
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 29298688) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
          seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
          seed[ 1] = Y_MASS[(thread >> 1) & 7];     // 2^3
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
       } else
       if(thread < 30347264) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
          seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
          seed[ 1] = X_MASS[(thread >> 2) & 3];     // 2^2
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
       } else
       if(thread < 30871552) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
          seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
          seed[ 1] = X_MASS[(thread >> 1) & 3];     // 2^2
+         seed[ 2] = 1;
          seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
          seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 5] = 1;
          seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
-      }
+      } else
       /* END Frame 6 */
-   } else if(thread < 42799104) {
       /* Frame 7 -> Split 9 ways */
-      /* Consistant values */
-      seed[ 0] = Z_TIME[(thread & 15)];            // 2^4
-      seed[ 1] = Z_AMB[(thread >> 4) & 15];        // 2^4
-      seed[ 2] = 1;
-      seed[ 3] = Z_ADJ[(thread >> 8) & 63];        // 2^6
-      seed[ 5] = 1;
-      /* Inconsistant seed values */
       if(thread < 35065856) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
-         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
-         seed[ 6] = Z_ING[(thread >> 18) & 15];    // 2^4
-      } else
-      if(thread < 37163088) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
-         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
-         seed[ 6] = Z_ING[(thread >> 17) & 15];    // 2^4
-      } else
-      if(thread < 38211584) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
-         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
-         seed[ 6] = Z_ING[(thread >> 16) & 15];    // 2^4
-      } else
-      if(thread < 40308736) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
-         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
-         seed[ 6] = Y_ING[(thread >> 18) & 7];     // 2^3
-      } else
-      if(thread < 41357312) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
-         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
-         seed[ 6] = Y_ING[(thread >> 17) & 7];     // 2^3
-      } else
-      if(thread < 41881600) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
-         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
-         seed[ 6] = Y_ING[(thread >> 16) & 7];     // 2^3
-      } else
-      if(thread < 42405888) { /* Total Permutations, this frame: 524,288 ( 1 << 19  ) */
-         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
-         seed[ 6] = X_ING[(thread >> 18) & 1];     // 2^1
-      } else
-      if(thread < 42668032) { /* Total Permutations, this frame: 262,144 ( 1 << 18 ) */
-         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
-         seed[ 6] = X_ING[(thread >> 17) & 1];     // 2^1
-      } else
-      if(thread < 42799104) { /* Total Permutations, this frame: 131,072 ( 1 << 17 ) */
-         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
-         seed[ 6] = X_ING[(thread >> 16) & 1];     // 2^1
-      }
-      /* END Frame 7 */
-   } else if(thread < 445452288) {
-      /* Frame 8 -> Split 2 ways */
-      /* Consistant values */
          seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
          seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
          seed[ 2] = 1;
-         seed[ 4] = 5;
-         seed[ 7] = 3;
-         seed[ 8] = 1;
-      /* Inconsistant seed values */
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 5] = 1;
+         seed[ 6] = Z_ING[(thread >> 18) & 15];    // 2^4
+      } else
+      if(thread < 37163088) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 5] = 1;
+         seed[ 6] = Z_ING[(thread >> 17) & 15];    // 2^4
+      } else
+      if(thread < 38211584) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 5] = 1;
+         seed[ 6] = Z_ING[(thread >> 16) & 15];    // 2^4
+      } else
+      if(thread < 40308736) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 5] = 1;
+         seed[ 6] = Y_ING[(thread >> 18) & 7];     // 2^3
+      } else
+      if(thread < 41357312) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 5] = 1;
+         seed[ 6] = Y_ING[(thread >> 17) & 7];     // 2^3
+      } else
+      if(thread < 41881600) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 5] = 1;
+         seed[ 6] = Y_ING[(thread >> 16) & 7];     // 2^3
+      } else
+      if(thread < 42405888) { /* Total Permutations, this frame: 524,288 ( 1 << 19  ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 5] = 1;
+         seed[ 6] = X_ING[(thread >> 18) & 1];     // 2^1
+      } else
+      if(thread < 42668032) { /* Total Permutations, this frame: 262,144 ( 1 << 18 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 5] = 1;
+         seed[ 6] = X_ING[(thread >> 17) & 1];     // 2^1
+      } else
+      if(thread < 42799104) { /* Total Permutations, this frame: 131,072 ( 1 << 17 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 3] = Z_ADJ[(thread >> 8) & 63];     // 2^6
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 5] = 1;
+         seed[ 6] = X_ING[(thread >> 16) & 1];     // 2^1
+      } else
+      /* END Frame 7 */
+      /* Frame 8 -> Split 2 ways */
       if(thread < 311234560) { /* Total Permutations, this frame: 268,435,456 ( 1 << 28 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
          seed[ 3] = Z_PREP[(thread >> 8) & 3];     // 2^2
+         seed[ 4] = 5;
          seed[ 5] = Z_ADJ[(thread >> 10) & 63];    // 2^6
          seed[ 6] = Z_NS[(thread >> 16) & 63];     // 2^6
+         seed[ 7] = 3;
+         seed[ 8] = 1;
          seed[ 9] = Z_INGADJ[(thread >> 22) & 63]; // 2^6
       } else
       if(thread < 445452288) { /* Total Permutations, this frame: 134,217,728 ( 1 << 27 ) */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
          seed[ 3] = Y_PREP[(thread >> 8) & 1];     // 2^1
+         seed[ 4] = 5;
          seed[ 5] = Z_ADJ[(thread >> 9) & 63];     // 2^6
          seed[ 6] = Z_NS[(thread >> 15) & 63];     // 2^6
+         seed[ 7] = 3;
+         seed[ 8] = 1;
          seed[ 9] = Z_INGADJ[(thread >> 21) & 63]; // 2^6
       }
-   }
 
 /* Below Two Frames are Valid, But Require 64-Bit Math: if extra entropy req'd.
    if( < thread <= ) { /* Total Permutations, this frame: 549,755,813,888
@@ -594,48 +688,49 @@ __global__ void trigg(uint32_t threads, int *g_found, uint8_t *g_seed)
    }
 End 64-bit Frames */
 
-   #pragma unroll
-   for (int i = 0; i < 8; i++)
-   {
-      input[i] = c_input32[i];
-   }
-   #pragma unroll
-   for (int i = 0; i < 4; i++)
-   {
-      input[8 + i] = cuda_swab32(((uint32_t *) seed)[i]);
-   }
+        #pragma unroll
+        for (int i = 0; i < 8; i++)
+        {
+            input[i] = c_input32[i];
+        }
+        #pragma unroll
+        for (int i = 0; i < 4; i++)
+        {
+            input[8 + i] = cuda_swab32(((uint32_t *) seed)[i]);
+        }
 
-   input[12] = cuda_swab32(c_blockNumber8[0]);
-   input[13] = cuda_swab32(c_blockNumber8[1]);
-   input[14] = 0x80000000;
-   input[15] = 0;
+        input[12] = cuda_swab32(c_blockNumber8[0]);
+        input[13] = cuda_swab32(c_blockNumber8[1]);
+        input[14] = 0x80000000;
+        input[15] = 0;
 
-   #pragma unroll
-   for (int i = 0; i < 8; i += 2)
-   {
-      AS_UINT2(&state[i]) = AS_UINT2(&c_midstate256[i]);
-   }
+        #pragma unroll
+        for (int i = 0; i < 8; i += 2)
+        {
+            AS_UINT2(&state[i]) = AS_UINT2(&c_midstate256[i]);
+        }
 
-   sha256_round(input, state, c_K);
+        sha256_round(input, state, c_K);
 
-   #pragma unroll
-   for (int i = 0; i < 15; i++)
-   {
-      input[i] = 0;
-   }
-   input[15] = 0x9c0;
+        #pragma unroll
+        for (int i = 0; i < 15; i++)
+        {
+            input[i] = 0;
+        }
+        input[15] = 0x9c0;
 
-   sha256_round(input, state, c_K);
+        sha256_round(input, state, c_K);
 
-   if (gpu_trigg_eval(state, c_difficulty))
-   {
-      *g_found = 1;
-      #pragma unroll
-      for (int i = 0; i < 16; i++)
-      {
-         g_seed[i] = seed[i];
-      }
-   }
+        if (gpu_trigg_eval(state, c_difficulty))
+        {
+            *g_found = 1;
+            #pragma unroll
+            for (int i = 0; i < 16; i++)
+            {
+                g_seed[i] = seed[i];
+            }
+        }
+    }
 }
 
 extern "C" {

--- a/src/trigg/cuda_trigg.cu
+++ b/src/trigg/cuda_trigg.cu
@@ -234,105 +234,334 @@ __device__ int gpu_trigg_eval(uint32_t *h, uint8_t d)
     return __clz(*bp) >= (d & 31);
 }
 
-__constant__ static int Z_PREP[8]  = {12,13,14,15,16,17,12,13}; /* Confirmed */
-__constant__ static int Z_ING[32]  = {18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,23,24,31,32,33,34}; /* Confirmed */
-__constant__ static int Z_INF[16]  = {44,45,46,47,48,50,51,52,53,54,55,56,57,58,59,60}; /* Confirmed */
-__constant__ static int Z_ADJ[64]  = {61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,94,95,96,97,98,99,100,101,102,103,104,105,107,108,109,110,112,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128}; /* Confirmed */
-__constant__ static int Z_AMB[16]  = {77,94,95,96,126,214,217,218,220,222,223,224,225,226,227,228}; /* Confirmed */
-__constant__ static int Z_TIMED[8] = {84,243,249,250,251,252,253,255}; /* Confirmed */
-__constant__ static int Z_NS[64] = {129,130,131,132,133,134,135,136,137,138,145,149,154,155,156,157,177,178,179,180,182,183,184,185,186,187,188,189,190,191,192,193,194,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,241,244,245,246,247,248,249,250,251,252,253,254,255}; /* Confirmed */
-__constant__ static int Z_NPL[32] = {139,140,141,142,143,144,146,147,148,150,151,153,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,181}; /* Confirmed */
-__constant__ static int Z_MASS[32] = {214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,242,214,215,216,219}; /* Confirmed */
-__constant__ static int Z_INGINF[32] = {18,19,20,21,22,25,26,27,28,29,30,36,37,38,39,40,41,42,44,46,47,48,49,51,52,53,54,55,56,57,58,59}; /* Confirmed */
-__constant__ static int Z_TIME[16] = {82,83,84,85,86,87,88,243,249,250,251,252,253,254,255,253}; /* Confirmed */
-__constant__ static int Z_INGADJ[64]  = {18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,23,24,31,32,33,34,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92};/* Confirmed */
+__constant__ static int Z_PREP[4]  = {12,13,14,15};
+__constant__ static int Y_PREP[2]  = {16,17};
+__constant__ static int Z_ING[16]  = {18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33};
+__constant__ static int Y_ING[8]   = {34,35,36,37,38,39,40,41};
+__constant__ static int X_ING[2]   = {42,43};
+__constant__ static int Z_INF[16]  = {44,45,46,47,48,50,51,52,53,54,55,56,57,58,59,60};
+__constant__ static int Z_ADJ[64]  = {61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,94,95,96,97,98,99,100,101,102,103,104,105,107,108,109,110,112,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128};
+__constant__ static int Z_AMB[16]  = {77,94,95,96,126,214,217,218,220,222,223,224,225,226,227,228};
+__constant__ static int Z_TIMED[8] = {84,243,249,250,251,252,253,255};
+__constant__ static int Z_NS[64]   = {129,130,131,132,133,134,135,136,137,138,145,149,154,155,156,157,177,178,179,180,182,183,184,185,186,187,188,189,190,191,192,193,194,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,241,244,245,246,247,248,249,250,251,252,253,254,255};
+__constant__ static int Z_NPL[32]  = {139,140,141,142,143,144,146,147,148,150,151,153,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,181};
+__constant__ static int Z_MASS[16] = {214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229};
+__constant__ static int Y_MASS[8]  = {230,231,232,233,234,235,236,237};
+__constant__ static int X_MASS[4]  = {238,239,240,242};
+__constant__ static int Z_INGINF[32] = {18,19,20,21,22,25,26,27,28,29,30,36,37,38,39,40,41,42,44,46,47,48,49,51,52,53,54,55,56,57,58,59};
+__constant__ static int Z_TIME[16] = {82,83,84,85,86,87,88,243,249,250,251,252,253,254,255,253};
+__constant__ static int Z_INGADJ[64] = {18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,23,24,31,32,33,34,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92};
 
 __global__ void trigg(uint32_t threads, int *g_found, uint8_t *g_seed)
 {
- const uint32_t thread = blockDim.x * blockIdx.x + threadIdx.x;
- uint8_t seed[16] = {0};
- uint32_t input[16], state[8];
+   const uint32_t thread = blockDim.x * blockIdx.x + threadIdx.x;
+   uint8_t seed[16] = {0};
+   uint32_t input[16], state[8];
 
- if (thread <= threads) {
+   if(thread < 86016) {
+      /* Frame 1 -> Split 6 ways */
+      /* Consistant values */
+      seed[ 2] = 1;
+      seed[ 3] = 5;
+      seed[ 5] = 1;
+      /* Inconsistant seed values */
+      if(thread < 32768) { /* Total Permutations, this frame: 32,768 ( 1 << 15 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
+         seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
+         seed[ 6] = Z_ING[(thread >> 11) & 15]; // 2^4
+      } else
+      if(thread < 49152) { /* Total Permutations, this frame: 16,384 ( 1 << 14 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
+         seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
+         seed[ 6] = Z_ING[(thread >> 10) & 15]; // 2^4
+      } else
+      if(thread < 65536) { /* Total Permutations, this frame: 16,384 ( 1 << 14 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
+         seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
+         seed[ 6] = Y_ING[(thread >> 11) & 7];  // 2^3
+      } else
+      if(thread < 73728) { /* Total Permutations, this frame: 8,192 ( 1 << 13 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
+         seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
+         seed[ 6] = Y_ING[(thread >> 10) & 7];  // 2^3
+      } else
+      if(thread < 81920) { /* Total Permutations, this frame: 16,384 ( 1 << 13 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];       // 2^2
+         seed[ 1] = Z_TIMED[(thread >> 2) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 5) & 63];   // 2^6
+         seed[ 6] = X_ING[(thread >> 11) & 3];  // 2^2
+      } else
+      if(thread < 86016) { /* Total Permutations, this frame: 8,192 ( 1 << 12 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];       // 2^1
+         seed[ 1] = Z_TIMED[(thread >> 1) & 7]; // 2^3
+         seed[ 4] = Z_NS[(thread >> 4) & 63];   // 2^6
+         seed[ 6] = X_ING[(thread >> 10) & 3];  // 2^2
+      }
+      /* END Frame 1 */
+   } else if(thread < 200704) {
+      /* Frame 2 -> Split 3 ways */
+      /* Consistant values */
+      seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+      seed[ 2] = 1;
+      seed[ 4] = 9;
+      seed[ 5] = 2;
+      seed[ 6] = 1;
+      /* Inconsistant seed values */
+      if(thread <= 151552) { /* Total Permutations, this frame: 65,536 (1 << 16) */
+         seed[ 1] = Y_MASS[(thread >> 4) & 15]; // 2^4
+         seed[ 3] = Z_INF[(thread >> 8) & 15];  // 2^4
+         seed[ 7] = Z_AMB[(thread >> 12) & 15]; // 2^4
+      } else
+      if(thread <= 184320) { /* Total Permutations, this frame: 32,768 (1 << 15) */
+         seed[ 1] = X_MASS[(thread >> 3) & 7];  // 2^3
+         seed[ 3] = Z_INF[(thread >> 7) & 15];  // 2^4
+         seed[ 7] = Z_AMB[(thread >> 11) & 15]; // 2^4
+      } else
+      if(thread <= 200704) { /* Total Permutations, this frame: 16,384 (1 << 14) */
+         seed[ 1] = Z_MASS[(thread >> 2) & 3];  // 2^2
+         seed[ 3] = Z_INF[(thread >> 6) & 15];  // 2^4
+         seed[ 7] = Z_AMB[(thread >> 10) & 15]; // 2^4
+      }
+      /* END Frame 2 */
+   } else if(thread < 3346432) {
+      /* Frame 3 -> Split 2 ways */
+      /* Consistant values */
+      seed[ 2] = 1;
+      seed[ 5] = 1;
+      /* Inconsistant seed values */
+      if(thread < 2297856) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 )*/
+         seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
+         seed[ 1] = Z_TIMED[(thread >> 2) & 7];    // 2^3
+         seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 3346432) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 )*/
+         seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
+         seed[ 1] = Z_TIMED[(thread >> 1) & 7];    // 2^3
+         seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
+      }
+      /* END Frame 3 */
+   } else if(thread < 8851456) {
+      /* Frame 4 -> Split 6 ways */
+      /* Consistant values */
+      seed[ 0] = 5;
+      seed[ 1] = Z_NS[(thread & 63)];              // 2^6
+      seed[ 2] = 1;
+      seed[ 6] = 3;
+      seed[ 7] = 1;
+      /* Inconsistant seed values */
+      if(thread < 5443584) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
+         seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
+         seed[ 5] = Z_MASS[(thread >> 11) & 15];   // 2^4
+         seed[ 8] = Z_ADJ[(thread >> 15) & 63];    // 2^6
+      } else
+      if(thread < 6492160) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
+         seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
+         seed[ 5] = Z_MASS[(thread >> 10) & 15];   // 2^4
+         seed[ 8] = Z_ADJ[(thread >> 14) & 63];    // 2^6
+      } else
+      if(thread < 7540736) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
+         seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
+         seed[ 5] = Y_MASS[(thread >> 11) & 7];    // 2^3
+         seed[ 8] = Z_ADJ[(thread >> 14) & 63];    // 2^6
+      } else
+      if(thread < 8065024) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
+         seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
+         seed[ 5] = Y_MASS[(thread >> 10) & 7];    // 2^3
+         seed[ 8] = Z_ADJ[(thread >> 13) & 63];    // 2^6
+      } else
+      if(thread < 8589312) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 3] = Z_PREP[(thread >> 6) & 3];     // 2^2
+         seed[ 4] = Z_TIMED[(thread >> 8) & 7];    // 2^3
+         seed[ 5] = X_MASS[(thread >> 11) & 3];    // 2^2
+         seed[ 8] = Z_ADJ[(thread >> 13) & 63];    // 2^6
+      } else
+      if(thread < 8851456) { /* Total Permutations, this frame: 262,144 ( 1 << 18 ) */
+         seed[ 3] = Y_PREP[(thread >> 6) & 1];     // 2^1
+         seed[ 4] = Z_TIMED[(thread >> 7) & 7];    // 2^3
+         seed[ 5] = X_MASS[(thread >> 10) & 3];    // 2^2
+         seed[ 8] = Z_ADJ[(thread >> 12) & 63];    // 2^6
+      }
+      /* END Frame 4 */
+   } else if(thread < 19861504) {
+      /* Frame 5 -> Split 6 ways */
+      /* Consistant values */
+      seed[ 3] = 1;
+      seed[ 5] = 1;
+      /* Inconsistant seed values */
+      if(thread < 13045760) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
+         seed[ 0] = Z_PREP[thread & 3];            // 2^2
+         seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
+         seed[ 2] = Z_MASS[(thread >> 8) & 15];    // 2^4
+         seed[ 4] = Z_NPL[(thread >> 12) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 17) & 31]; // 2^5
+      } else
+      if(thread < 15142912) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Y_PREP[thread & 1];            // 2^1
+         seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
+         seed[ 2] = Z_MASS[(thread >> 7) & 15];    // 2^4
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 17240064) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Z_PREP[thread & 3];            // 2^2
+         seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
+         seed[ 2] = Y_MASS[(thread >> 8) & 7];     // 2^3
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 18288640) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Y_PREP[thread & 1];            // 2^1
+         seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
+         seed[ 2] = Y_MASS[(thread >> 7) & 7];     // 2^3
+         seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
+      } else
+      if(thread < 19337216) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Z_PREP[thread & 3];            // 2^2
+         seed[ 1] = Z_ADJ[(thread >> 2) & 63];     // 2^6
+         seed[ 2] = X_MASS[(thread >> 8) & 3];     // 2^2
+         seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
+      } else
+      if(thread < 19861504) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 0] = Y_PREP[thread & 1];            // 2^1
+         seed[ 1] = Z_ADJ[(thread >> 1) & 63];     // 2^6
+         seed[ 2] = X_MASS[(thread >> 7) & 3];     // 2^2
+         seed[ 4] = Z_NPL[(thread >> 9) & 31];     // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 14) & 31]; // 2^5
+      }
+      /* END Frame 5 */
+   } else if(thread < 30871552) {
+      /* Frame 6 -> Split 6 ways */
+      /* Consistant values */
+      seed[ 2] = 1;
+      seed[ 5] = 1;
+      /* Inconsistant seed values */
+      if(thread < 24055808) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
+         seed[ 1] = Z_MASS[(thread >> 2) & 15];    // 2^4
+         seed[ 3] = Z_ADJ[(thread >> 6) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 12) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 17) & 31]; // 2^5
+      } else
+      if(thread < 26152960) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
+         seed[ 1] = Z_MASS[(thread >> 1) & 15];    // 2^4
+         seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 28250112) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
+         seed[ 1] = Y_MASS[(thread >> 2) & 7];     // 2^3
+         seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 29298688) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
+         seed[ 1] = Y_MASS[(thread >> 1) & 7];     // 2^3
+         seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
+      } else
+      if(thread < 30347264) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 0] = Z_PREP[(thread & 3)];          // 2^2
+         seed[ 1] = X_MASS[(thread >> 2) & 3];     // 2^2
+         seed[ 3] = Z_ADJ[(thread >> 5) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 11) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 16) & 31]; // 2^5
+      } else
+      if(thread < 30871552) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 0] = Y_PREP[(thread & 1)];          // 2^1
+         seed[ 1] = X_MASS[(thread >> 1) & 3];     // 2^2
+         seed[ 3] = Z_ADJ[(thread >> 4) & 63];     // 2^6
+         seed[ 4] = Z_NPL[(thread >> 10) & 31];    // 2^5
+         seed[ 6] = Z_INGINF[(thread >> 15) & 31]; // 2^5
+      }
+      /* END Frame 6 */
+   } else if(thread < 42799104) {
+      /* Frame 7 -> Split 9 ways */
+      /* Consistant values */
+      seed[ 0] = Z_TIME[(thread & 15)];            // 2^4
+      seed[ 1] = Z_AMB[(thread >> 4) & 15];        // 2^4
+      seed[ 2] = 1;
+      seed[ 3] = Z_ADJ[(thread >> 8) & 63];        // 2^6
+      seed[ 5] = 1;
+      /* Inconsistant seed values */
+      if(thread < 35065856) { /* Total Permutations, this frame: 4,194,304 ( 1 << 22 ) */
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 6] = Z_ING[(thread >> 18) & 15];    // 2^4
+      } else
+      if(thread < 37163088) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 6] = Z_ING[(thread >> 17) & 15];    // 2^4
+      } else
+      if(thread < 38211584) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 6] = Z_ING[(thread >> 16) & 15];    // 2^4
+      } else
+      if(thread < 40308736) { /* Total Permutations, this frame: 2,097,152 ( 1 << 21 ) */
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 6] = Y_ING[(thread >> 18) & 7];     // 2^3
+      } else
+      if(thread < 41357312) { /* Total Permutations, this frame: 1,048,576 ( 1 << 20 ) */
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 6] = Y_ING[(thread >> 17) & 7];     // 2^3
+      } else
+      if(thread < 41881600) { /* Total Permutations, this frame: 524,288 ( 1 << 19 ) */
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 6] = Y_ING[(thread >> 16) & 7];     // 2^3
+      } else
+      if(thread < 42405888) { /* Total Permutations, this frame: 524,288 ( 1 << 19  ) */
+         seed[ 4] = Z_MASS[(thread >> 14) & 15];   // 2^4
+         seed[ 6] = X_ING[(thread >> 18) & 1];     // 2^1
+      } else
+      if(thread < 42668032) { /* Total Permutations, this frame: 262,144 ( 1 << 18 ) */
+         seed[ 4] = Y_MASS[(thread >> 14) & 7];    // 2^3
+         seed[ 6] = X_ING[(thread >> 17) & 1];     // 2^1
+      } else
+      if(thread < 42799104) { /* Total Permutations, this frame: 131,072 ( 1 << 17 ) */
+         seed[ 4] = X_MASS[(thread >> 14) & 3];    // 2^2
+         seed[ 6] = X_ING[(thread >> 16) & 1];     // 2^1
+      }
+      /* END Frame 7 */
+   } else if(thread < 445452288) {
+      /* Frame 8 -> Split 2 ways */
+      /* Consistant values */
+         seed[ 0] = Z_TIME[(thread & 15)];         // 2^4
+         seed[ 1] = Z_AMB[(thread >> 4) & 15];     // 2^4
+         seed[ 2] = 1;
+         seed[ 4] = 5;
+         seed[ 7] = 3;
+         seed[ 8] = 1;
+      /* Inconsistant seed values */
+      if(thread < 311234560) { /* Total Permutations, this frame: 268,435,456 ( 1 << 28 ) */
+         seed[ 3] = Z_PREP[(thread >> 8) & 3];     // 2^2
+         seed[ 5] = Z_ADJ[(thread >> 10) & 63];    // 2^6
+         seed[ 6] = Z_NS[(thread >> 16) & 63];     // 2^6
+         seed[ 9] = Z_INGADJ[(thread >> 22) & 63]; // 2^6
+      } else
+      if(thread < 445452288) { /* Total Permutations, this frame: 134,217,728 ( 1 << 27 ) */
+         seed[ 3] = Y_PREP[(thread >> 8) & 1];     // 2^1
+         seed[ 5] = Z_ADJ[(thread >> 9) & 63];     // 2^6
+         seed[ 6] = Z_NS[(thread >> 15) & 63];     // 2^6
+         seed[ 9] = Z_INGADJ[(thread >> 21) & 63]; // 2^6
+      }
+   }
 
-   if(0 < thread <= 131071) { /* Total Permutations, this frame: 131,072 */
-	seed[ 0] = Z_PREP[(thread & 7)];  
-	seed[ 1] = Z_TIMED[(thread >> 3) & 7]; 
-	seed[ 2] = 1;
-        seed[ 3] = 5; 
-	seed[ 4] = Z_NS[(thread >> 6) & 63]; 
-	seed[ 5] = 1;
-        seed[ 6] = Z_ING[(thread >> 12) & 31];
-   }
-   if(131071 < thread <= 262143) { /* Total Permutations, this frame: 131,072 */
-	seed[ 0] = Z_TIME[(thread & 15)]; 
-	seed[ 1] = Z_MASS[(thread >> 4) & 31]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_INF[(thread >> 9) & 15]; 
-	seed[ 4] = 9; 
-	seed[ 5] = 2; 
-	seed[ 6] = 1;
-        seed[ 7] = Z_AMB[(thread >> 13) & 15];
-   }
-   if(262143 < thread <= 4456447) { /* Total Permutations, this frame: 4,194,304 */
-	seed[ 0] = Z_PREP[(thread & 7)]; 
-	seed[ 1] = Z_TIMED[(thread >> 3) & 7]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_ADJ[(thread >> 6) & 63]; 
-	seed[ 4] = Z_NPL[(thread >> 12) & 31];
-	seed[ 5] = 1;
-        seed[ 6] = Z_INGINF[(thread >> 17) & 31];
-   }
-   if(4456447 < thread <= 12845055) { /* Total Permutations, this frame: 8,388,608 */
-	seed[ 0] = 5; 
-	seed[ 1] = Z_NS[(thread & 63)]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_PREP[(thread >> 6) & 7];
-	seed[ 4] = Z_TIMED[(thread >> 9) & 7];
-	seed[ 5] = Z_MASS[(thread >> 12) & 31]; 
-	seed[ 6] = 3; 
-	seed[ 7] = 1;
-        seed[ 8] = Z_ADJ[(thread >> 17) & 63];
-   }
-   if(12845055 < thread <= 29622271) { /* Total Permutations, this frame: 16,777,216 */
-	seed[ 0] = Z_PREP[thread & 7];
-	seed[ 1] = Z_ADJ[(thread >> 3) & 63];
-	seed[ 2] = Z_MASS[(thread >> 9) & 31];
-	seed[ 3] = 1;
-        seed[ 4] = Z_NPL[(thread >> 14) & 31];
-	seed[ 5] = 1;
-        seed[ 6] = Z_INGINF[(thread >> 19) & 31];
-   }
-   if(29622271 < thread <= 46399487) { /* Total Permutations, this frame: 16,777,216 */
-	seed[ 0] = Z_PREP[(thread & 7)];  
-	seed[ 1] = Z_MASS[(thread >> 3) & 31]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_ADJ[(thread >> 8) & 63]; 
-	seed[ 4] = Z_NPL[(thread >> 14) & 31];  
-	seed[ 5] = 1;
-        seed[ 6] = Z_INGINF[(thread >> 19) & 31];
-   }
-   if(46399487 < thread <= 63176703) { /* Total Permutations, this frame: 16,777,216 */
-	seed[ 0] = Z_TIME[(thread & 15)]; 
-	seed[ 1] = Z_AMB[(thread >> 4) & 15]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_ADJ[(thread >> 8) & 63]; 
-	seed[ 4] = Z_MASS[(thread >> 14) & 31]; 
-	seed[ 5] = 1;
-        seed[ 6] = Z_ING[(thread >> 19) & 31];
-   }
-   if(63176703 < thread <= 600047615 ) { /* Total Permutations, this frame: 536,870,912 */
-	seed[ 0] = Z_TIME[(thread & 15)]; 
-	seed[ 1] = Z_AMB[(thread >> 4) & 15]; 
-	seed[ 2] = 1;
-        seed[ 3] = Z_PREP[(thread >> 8) & 7];
-	seed[ 4] = 5; 
-	seed[ 5] = Z_ADJ[(thread >> 11) & 63]; 
-	seed[ 6] = Z_NS[(thread >> 17) & 63]; 
-	seed[ 7] = 3;
-	seed[ 8] = 1;
-        seed[ 9] = Z_INGADJ[(thread >> 23) & 63];
-   }
 /* Below Two Frames are Valid, But Require 64-Bit Math: if extra entropy req'd.
    if( < thread <= ) { /* Total Permutations, this frame: 549,755,813,888
 	seed[ 0] = Z_ING[(thread & 31)]; 
@@ -365,49 +594,48 @@ __global__ void trigg(uint32_t threads, int *g_found, uint8_t *g_seed)
    }
 End 64-bit Frames */
 
-        #pragma unroll
-        for (int i = 0; i < 8; i++)
-        {
-            input[i] = c_input32[i];
-        }
-        #pragma unroll
-        for (int i = 0; i < 4; i++)
-        {
-            input[8 + i] = cuda_swab32(((uint32_t *) seed)[i]);
-        }
+   #pragma unroll
+   for (int i = 0; i < 8; i++)
+   {
+      input[i] = c_input32[i];
+   }
+   #pragma unroll
+   for (int i = 0; i < 4; i++)
+   {
+      input[8 + i] = cuda_swab32(((uint32_t *) seed)[i]);
+   }
 
-        input[12] = cuda_swab32(c_blockNumber8[0]);
-        input[13] = cuda_swab32(c_blockNumber8[1]);
-        input[14] = 0x80000000;
-        input[15] = 0;
+   input[12] = cuda_swab32(c_blockNumber8[0]);
+   input[13] = cuda_swab32(c_blockNumber8[1]);
+   input[14] = 0x80000000;
+   input[15] = 0;
 
-        #pragma unroll
-        for (int i = 0; i < 8; i += 2)
-        {
-            AS_UINT2(&state[i]) = AS_UINT2(&c_midstate256[i]);
-        }
+   #pragma unroll
+   for (int i = 0; i < 8; i += 2)
+   {
+      AS_UINT2(&state[i]) = AS_UINT2(&c_midstate256[i]);
+   }
 
-        sha256_round(input, state, c_K);
+   sha256_round(input, state, c_K);
 
-        #pragma unroll
-        for (int i = 0; i < 15; i++)
-        {
-            input[i] = 0;
-        }
-        input[15] = 0x9c0;
+   #pragma unroll
+   for (int i = 0; i < 15; i++)
+   {
+      input[i] = 0;
+   }
+   input[15] = 0x9c0;
 
-        sha256_round(input, state, c_K);
+   sha256_round(input, state, c_K);
 
-        if (gpu_trigg_eval(state, c_difficulty))
-        {
-            *g_found = 1;
-            #pragma unroll
-            for (int i = 0; i < 16; i++)
-            {
-                g_seed[i] = seed[i];
-            }
-        }
-    }
+   if (gpu_trigg_eval(state, c_difficulty))
+   {
+      *g_found = 1;
+      #pragma unroll
+      for (int i = 0; i < 16; i++)
+      {
+         g_seed[i] = seed[i];
+      }
+   }
 }
 
 extern "C" {
@@ -422,8 +650,8 @@ typedef struct __trigg_cuda_ctx {
 } TriggCudaCTX;
 
 TriggCudaCTX ctx[64];    /* Max 64 GPUs Supported */
-int threads = 600047615;
-dim3 grid(585984);
+int threads = 445452288;
+dim3 grid(435012);
 dim3 block(1024);
 char nullcp = '\0';
 byte *diff;


### PR DESCRIPTION
This implementation increases efficiency by splitting up effected haiku values into multiple groups of 2^(n) instead of expanding a single group with duplicate values to reach 2^(n) values. Unfortunately, this comes at the cost of increased code size, as haiku frames must also be split up in alignment with the associated multiple groups of 2^(n) haiku values. However, this allows the code to maintain an unbroken test of solutions (as opposed to skipping seeds) while increasing efficiency (theoretically) by about 34% due to the overall reduction in threads required from 600,047,615 to 445,452,288.

Verification Test:
Real world (practical) verification tests have proven to be more efficient.
The test environment was made to find 300 solutions at a minimum difficulty of 31 from merkle root's provided by the testnet, as fast as possible. The test environment used a single GTX765m, tests were performed multiple times to rule out anomalies, and during all tests the miner displayed a hashrate of around 80MH/s (calculated by the miner, based on total hashes performed by the GPU).

Results:
The original CUDA code found 300 solutions in 13,859 seconds of solving time. Giving an EFFECTIVE hashrate of approximately 46MH/s.
The optimised CUDA code found 300 solutions in 8977 seconds of solving time. Giving an EFFECTIVE hashrate of approximately 71MH/s.
This gives us an EFFECTIVE hashrate increase of about 54% on this test environment. I might expect different rigs to yield slightly different results depending on conditions.