### PR TITLE
Add support for local peer list

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -39,6 +39,7 @@ word32 Lastday;
 byte Exportflag;     /* allow database export if compiled         */
 #endif
 
+
 /*
  * real time of current server loop - set by server()
  */
@@ -58,6 +59,10 @@ word32 Rplist[RPLISTLEN];  /* recent peer list */
 word32 Rplistidx;
 word32 Cplist[CPLISTLEN];  /* current peer list */
 word32 Cplistidx;
+/* LAN peer list */
+#define LPLISTLEN 32
+word32 Lplist[LPLISTLEN] = { 0 };
+word32 Splist[RPLISTLEN+LPLISTLEN] = {0};
 
 #define CORELISTLEN 16
 #if CORELISTLEN > RPLISTLEN
@@ -102,6 +107,7 @@ word32 Peerip;            /* gift to bval and others */
 byte Disable_pink;
 byte Needcleanup;         /* set true when Winsock is started */
 char *Corefname = "coreip.lst";  /* Master ip list by main() */
+char *Lpfname = "\0";  /* Local peer ip list by main() */
 pid_t Bcpid;              /* bcon process id */
 byte Bcbnum[8];           /* Cblocknum at time of execl bcon */
 pid_t Sendfound_pid;

--- a/src/init.c
+++ b/src/init.c
@@ -120,6 +120,40 @@ int read_coreipl(char *fname)
    return j;
 }  /* end read_coreipl() */
 
+/* Read-in the local ip list text file
+ * each line:
+ * 1.2.3.4  or
+ * host.domain.name
+ */
+int read_localipl(char *fname)
+{
+   FILE *fp;
+   char buff[128];
+   int j;
+   char *addrstr;
+   word32 ip;
+
+   if(Trace) plog("Entering read_localipl()");
+   if(fname == NULL || *fname == '\0') return VERROR;
+   fp = fopen(fname, "rb");
+   if(fp == NULL) return VERROR;
+
+   for(j = 0; j < LPLISTLEN; ) {
+      if(fgets(buff, 128, fp) == NULL) break;
+      if(*buff == '#') continue;
+      addrstr = strtok(buff, " \r\n\t");
+      if(Trace > 1) plog("   parse: %s", addrstr);  /* debug */
+      if(addrstr == NULL) break;
+      ip = str2ip(addrstr);
+      if(!ip) continue;
+      /* put ip in Lplist[j] */
+      Lplist[j++] = ip;
+      if(Trace) plog("Added 0x%08x to Lplist", ip);  /* debug */
+   }
+   fclose(fp);
+   return j;
+}  /* end read_localipl() */
+
 
 /* Get an ip list from ip and copy it into np,
  * also call addrecent() on the list.
@@ -974,6 +1008,10 @@ int init(void)
       fatal("init(): bad tfile.dat -- gomochi!");
    }
    memcpy(Weight, wp, HASHLEN);
+
+   /* read local nodes into Lplist */
+   read_localipl(Lpfname);
+
 
    /* read into Coreplist[], shuffle, and get IPL */
    if(*Corefname)

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -155,10 +155,26 @@ byte Frisky;  /* command line switch */
  */
 pid_t mirror(void)
 {
-   if(Frisky)
-      return mirror1(Rplist, RPLISTLEN);
-   else
-      return mirror1(Cplist, CPLISTLEN);
+   int i;
+   int num_lan = 0;
+   for (i = 0; i < LPLISTLEN; i++) {
+      if (Lplist[i] == 0) break; /* no more local peers in list */
+      Splist[i] = Lplist[i];
+      num_lan++;
+   }
+   if(Frisky) {
+      for (i = 0; i < RPLISTLEN; i++) {
+         Splist[i+num_lan] = Rplist[i];
+      }
+      //return mirror1(Rplist, RPLISTLEN);
+      return mirror1(Splist, RPLISTLEN+num_lan);
+   } else {
+      for (i = 0; i < CPLISTLEN; i++) {
+         Splist[i+num_lan] = Cplist[i];
+      }
+      //return mirror1(Cplist, CPLISTLEN);
+      return mirror1(Splist, CPLISTLEN+num_lan);
+   }
 }
 
 

--- a/src/mochimo.c
+++ b/src/mochimo.c
@@ -66,6 +66,7 @@ void usage(void)
           "         -qN        set Quorum to N (default 4)\n"
           "         -vN        set virtual mode: N = 1 or 2\n"
           "         -cFNAME    read core ip list from FNAME\n"
+          "         -LFNAME    read local peer ip list from FNAME\n"
           "         -c         disable read core ip list\n"
           "         -d         disable pink lists\n"
           "         -pN        set port to N\n"
@@ -144,6 +145,8 @@ int main(int argc, char **argv)
          case 'e':  Errorlog = 1;  /* enable "error.log" file */
                     break;
          case 'c':  Corefname = &argv[j][2];  /* master network */
+                    break;
+         case 'L':  Lpfname = &argv[j][2];  /* local peer network */
                     break;
          case 'd':  Disable_pink = 1;  /* disable pink lists */
                     break;

--- a/src/proto.h
+++ b/src/proto.h
@@ -37,6 +37,7 @@ int get_block2(word32 ip, byte *bnum, char *fname, word16 opcode);
 /* Source file: init.c */
 int get_ipl(NODE *np, word32 ip);
 int read_coreipl(char *fname);
+int read_localipl(char *fname);
 word32 init_coreipl(NODE *np, char *fname);
 void add_weight(byte *weight, int difficulty, byte *bnum);
 int cmp_weight(byte *w1, byte *w2);

--- a/src/update.c
+++ b/src/update.c
@@ -62,6 +62,14 @@ bad:
       send_op(&node, OP_FOUND);
       closesocket(node.sd);
    }
+   /* Send found message to local peers */
+   for(ipp = Lplist; ipp < &Lplist[LPLISTLEN] && Running; ipp++) {
+      if(*ipp == 0) continue;
+      if(callserver(&node, *ipp) != VEOK) continue;
+      memcpy(&node.tx, &tx, sizeof(TX));  /* copy in tfile proof */
+      send_op(&node, OP_FOUND);
+      closesocket(node.sd);
+   }
    exit(0);
 }  /* end send_found() */
 


### PR DESCRIPTION
Makes running multiple rigs behind the same ip easier and more reliable.

On the master node (the one with the public ip, or forwarded port in firewall):
* Create a file named local.lst containing a list of IPs for all other local nodes.
* Start mining with `./gomochi d -L../local.lst` (make sure to remove the -F flag first from the master and all local nodes)
This makes it so that the master node ALWAYS sends block updates and TXs to the local nodes, in addition to the regular peers.