### PR TITLE
Initial MTX Messaging layer proposal

### DIFF
--- a/src/bx.c
+++ b/src/bx.c
@@ -795,7 +795,7 @@ int iszero(void *buff, int len)
 
 int txmenu(BHEADER *bh, BTRAILER *bt)
 {
-   char buff[80];
+   char buff[80], *memo;
    TXQENTRY txq;
    word32 j, k;
    word32 tcount;
@@ -833,6 +833,10 @@ int txmenu(BHEADER *bh, BTRAILER *bt)
          mtx = (MTX *) &txq;
          for(j = k = 0; j < NR_DST; j++) {
             if(iszero(mtx->dst[j].tag, ADDR_TAG_LEN)) break;
+            if(ismtxmemo(&txq) && *(mtx->dst[j].tag) == 0x00) {
+               memo = &(mtx->dst[j].tag[1]);
+               break;
+            }
             if(++k >= 10) {
                k = 0;
                printf("Press RETURN or 'q': ");
@@ -857,6 +861,9 @@ int txmenu(BHEADER *bh, BTRAILER *bt)
       printf("  [0x%s]\n", b2hex8(txq.change_total));
       printf("fee:          %s\n", itoa64lj(txq.tx_fee, NULL, 9, 1));
       printf("sig:        0x");  bytes2hex(txq.tx_sig, 32);
+
+      if(ismtxmemo(&txq))
+         printf("\nmemo: %s", memo);
 
       printf("\nq=quit, g=goto TX, RETURN=next, b=back, "
              "p=previous menu: "

--- a/src/mtxval.c
+++ b/src/mtxval.c
@@ -6,6 +6,7 @@
  * Date: 6 May 2019
 */
 
+#include <ctype.h>  /* for isprint() */
 
 #define BAIL(m) { message = m; goto bail; }
 

--- a/src/types.h
+++ b/src/types.h
@@ -167,7 +167,11 @@ typedef struct {
 /* for mtx */
 /* takes TX * or TXQENTRY pointer */
 #define ismtx(tx) ((tx)->dst_addr[2196] == 0x00 \
-                    && (tx)->dst_addr[2197] == 0x01)
+                    && ((tx)->dst_addr[2197] == 0x01 \
+                        || (tx)->dst_addr[2197] == 0x02))
+/* identifies mtx/memo combination mtx */
+#define ismtxmemo  ((tx)->dst_addr[2196] == 0x00 \
+                      && (tx)->dst_addr[2197] == 0x02 )
 
 #define ADDR_TAG_LEN 12
 #define NR_DST 100       /* number of tags (MDST) in MTX dst[] */


### PR DESCRIPTION
This commit proposes suggested validation logic for a messaging layer
that would exist as an extension to the existing MTX logic available
from v2.4.1 of the codebase. The messaging layer would allow a sender
of a transaction to append a message (known in the code as a memo) to
the last destination tag of an MTX, using any remaining space available
in the dst[] field.

Messaging layer specification:
To maintain transaction type conformity, a transaction identified as a
MTX Memo transaction SHALL have a memo exist in the transaction.
To distinguish a memo from the dst[] tags, a memo SHALL always begin
and end with a zero (0) byte (null termination char).
To avoid binary abuse of the messaging layer, a memo SHALL contain only
printable characters, as per the default C locale, and any remaining
dst[] array space AFTER the the end of a memo SHALL be zero filled.
To offset the validation costs of longer messages, the fee incurred for
a memo of a certain length shall be equal to the fees incurred by tags
that would otherwise use such a length.

The fee formula:
   (messagefees) = (fee) * (1 + ((messagelength + 1) / sizeof(MDST)))

'1 + ...' ensures that a fee is always paid by messages that do not
utilize the entire space (MDST) of a dst[] field.
'... (messagelength + 1) ...' ensures the initial zero (0) byte,
which utilizes dst[] tag space, is accounted for in fee calculation.

Notes...
Currently the fee calculation does not include the required ending zero
byte terminating character. This allows a message to include a network
fee for the first 19 characters and a subsequent network fee for every
20 characters thereafter. Accounting for the ending zero byte will
introduce further (and objectively) unecessary validation processes.