### PR TITLE
Feature/partial address search

### DIFF
--- a/src/bval.c
+++ b/src/bval.c
@@ -404,7 +404,7 @@ fee_overflow:
          if(iszero(mtx->dst[j].tag, ADDR_TAG_LEN)) break; /* end of dst[] */
          memcpy(ADDR_TAG_PTR(addr), mtx->dst[j].tag, ADDR_TAG_LEN);
          /* If dst[j] tag not found, write money back to chg addr. */
-         if(tag_find(addr, addr, NULL) != VEOK) {
+         if(tag_find(addr, addr, NULL, ADDR_TAG_LEN) != VEOK) {
             count =  fwrite(mtx->chg_addr, TXADDRLEN, 1, ltfp);
             count += fwrite("A", 1, 1, ltfp);
             count += fwrite(mtx->dst[j].amount, 8, 1, ltfp);

--- a/src/bval.c
+++ b/src/bval.c
@@ -298,7 +298,7 @@ badread:
          baddrop("WOTS signature failed!");
 
       /* look up source address in ledger */
-      if(le_find(tx.src_addr, &src_le, NULL, 0) == FALSE)
+      if(le_find(tx.src_addr, &src_le, NULL, TXADDRLEN) == FALSE)
          drop("src_addr not in ledger");
 
       total[0] = total[1] = 0;
@@ -357,7 +357,7 @@ fee_overflow:
       }  /* end for qp2 */
    }  /* end for qp1 */
 
-   /* 
+   /*
     * Three times is the charm...
     */
    for(Tnum = 0, qp1 = Q2; qp1 < qlimit; qp1++, Tnum++) {
@@ -388,7 +388,7 @@ fee_overflow:
       }
    }  /* end for Tnum -- scan 3 */
 
-   
+
    if(Tnum != tcount) bail("scan 3");
    /* mtx tag search  Begin scan 4 ...
     *
@@ -421,7 +421,7 @@ fee_overflow:
             if(memcmp(ADDR_TAG_PTR(qp2->src_addr),
                       ADDR_TAG_PTR(qp2->chg_addr), ADDR_TAG_LEN) != 0)
                          continue;
-            if(memcmp(ADDR_TAG_PTR(qp2->src_addr), ADDR_TAG_PTR(addr), 
+            if(memcmp(ADDR_TAG_PTR(qp2->src_addr), ADDR_TAG_PTR(addr),
                       ADDR_TAG_LEN) == 0) {
                          memcpy(addr, qp2->chg_addr, TXADDRLEN);
                          break;

--- a/src/execute.c
+++ b/src/execute.c
@@ -24,6 +24,10 @@ int send_balance(NODE *np)
 
    put64(np->tx.send_total, zeros);
    len = get16(np->tx.len);
+   /* check for old OP_BALANCE Request with ZEROED Tag */
+   if(len == 0 && ((byte *) (np->tx.src_addr))[2196] == 0x00) {
+     len = TXADDRLEN - 12;
+   }
    /* look up source address in ledger */
    if(le_find(np->tx.src_addr, &le, NULL, len) == TRUE) {
      put64(np->tx.send_total, le.balance);

--- a/src/execute.c
+++ b/src/execute.c
@@ -22,8 +22,9 @@ int send_balance(NODE *np)
    word16 len;
    static byte zeros[8];
 
-   put64(np->tx.send_total, zeros);
    len = get16(np->tx.len);
+   put64(np->tx.send_total, zeros);
+   put64(np->tx.change_total, zeros);
    /* check for old OP_BALANCE Request with ZEROED Tag */
    if(len == 0 && ((byte *) (np->tx.src_addr))[2196] == 0x00) {
      len = TXADDRLEN - 12;
@@ -31,10 +32,8 @@ int send_balance(NODE *np)
    /* look up source address in ledger */
    if(le_find(np->tx.src_addr, &le, NULL, len) == TRUE) {
      put64(np->tx.send_total, le.balance);
-     /* return found address on partial search */
-     if(len != TXADDRLEN) {
-       memcpy(np->tx.src_addr, le.addr, TXADDRLEN);
-     }
+     put64(np->tx.change_total, One); /* indicate address was found */
+     memcpy(np->tx.src_addr, le.addr, TXADDRLEN); /* return found address */
    }
    send_op(np, OP_SEND_BAL);
    return 0;  /* success */

--- a/src/execute.c
+++ b/src/execute.c
@@ -25,7 +25,7 @@ int send_balance(NODE *np)
    put64(np->tx.send_total, zeros);
    len = get16(np->tx.len);
    /* look up source address in ledger */
-   if(le_find(np->tx.srcaddr, &le, NULL, len) == TRUE) {
+   if(le_find(np->tx.src_addr, &le, NULL, len) == TRUE) {
      put64(np->tx.send_total, le.balance);
      /* return found address on partial search */
      if(len != TXADDRLEN) {

--- a/src/ledger.c
+++ b/src/ledger.c
@@ -52,7 +52,7 @@ void le_close(void)
  * If position is non-NULL put the index of found LENTRY struct there,
  * else the index of where to insert addr in ledger.dat.
  */
-int le_find(byte *addr, LENTRY *le, long *position, int mode)
+int le_find(byte *addr, LENTRY *le, long *position, word16 len)
 {
    long cond, mid, hi, low;
    size_t addrlen;
@@ -64,7 +64,7 @@ int le_find(byte *addr, LENTRY *le, long *position, int mode)
 
    low = 0;
    hi = Nledger - 1;
-   if(mode == 1) addrlen = TXADDRLEN-12; else addrlen = TXADDRLEN;
+   addrlen = len;
 
    while(low <= hi) {
       mid = (hi + low) / 2;

--- a/src/mtxval.c
+++ b/src/mtxval.c
@@ -25,7 +25,7 @@ int mtx_val(MTX *mtx, word32 *fee)
 
    /* Check that src and chg have tags.
     * Check that src and chg have same tag.
-    * tx_val() or bval.c has already checked src != chg, src exists, 
+    * tx_val() or bval.c has already checked src != chg, src exists,
     *   sig is good, and totals are good.
     */
    if(!HAS_TAG(mtx->src_addr)) BAIL(1);
@@ -55,7 +55,7 @@ int mtx_val(MTX *mtx, word32 *fee)
          memcpy(ADDR_TAG_PTR(addr), mtx->dst[j].tag, ADDR_TAG_LEN);
          mtx->zeros[j] = 0;
          /* If dst[j] tag not found, put error code in zeros[] array. */
-         if(tag_find(addr, NULL, NULL) != VEOK) mtx->zeros[j] = 1;
+         if(tag_find(addr, NULL, NULL, ADDR_TAG_LEN) != VEOK) mtx->zeros[j] = 1;
       }
    }  /* end for j */
    /* Check tallies... */

--- a/src/tag.c
+++ b/src/tag.c
@@ -203,7 +203,7 @@ int tag_valid(byte *src_addr, byte *chg_addr, byte *dst_addr, byte *bnum)
          /* If there is a dst_tag, and its full address is not
           * already in ledger.dat, tx is not valid.
           */
-         if(le_find(dst_addr, &le, NULL, 0) == FALSE) {
+         if(le_find(dst_addr, &le, NULL, TXADDRLEN) == FALSE) {
             plog("DST_ADDR Tagged, but Tag is not in ledger!");
             goto bad;
          }
@@ -217,7 +217,7 @@ int tag_valid(byte *src_addr, byte *chg_addr, byte *dst_addr, byte *bnum)
 
    /* If tags are not the same and the src is not default, tx invalid. */
    if(HAS_TAG(src_addr)) {
-      plog("SRC_TAG != CHG_TAG, and SRC_TAG is Non-Default!"); 
+      plog("SRC_TAG != CHG_TAG, and SRC_TAG is Non-Default!");
       goto bad;
    }
    /* Otherwise, check all queues and ledger.dat for change tag.

--- a/src/tag.c
+++ b/src/tag.c
@@ -271,6 +271,7 @@ int tag_resolve(NODE *np)
    int status, ecode = VERROR;
 
    put64(np->tx.send_total, zeros);
+   put64(np->tx.change_total, zeros);
    /* find tag in leger.dat */
    status = tag_find(np->tx.dst_addr, foundaddr, balance, get16(np->tx.len));
    if(status == VEOK) {

--- a/src/tests/tagindex/testtag.c
+++ b/src/tests/tagindex/testtag.c
@@ -41,7 +41,7 @@ int main()
    printf("sizeof(LENTRY) = %u\n", (int) sizeof(LENTRY));
    strcpy((char *) ADDR_TAG_PTR(le.addr), "badtag");
    printf("tag_find('%-12.12s')\n", (char *) ADDR_TAG_PTR(le.addr));
-   status = tag_find(le.addr, le.addr, le.balance);
+   status = tag_find(le.addr, le.addr, le.balance, ADDR_TAG_LEN);
    printf("tag_find() returned %d  S/B 1\n", status);
 
    printf("Tags:\n");
@@ -52,7 +52,7 @@ int main()
    memset(ADDR_TAG_PTR(le.addr), 0, ADDR_TAG_LEN);
    strcpy((char *) ADDR_TAG_PTR(le.addr), "123");
    printf("tag_find('%-12.12s')\n", (char *) ADDR_TAG_PTR(le.addr));
-   status = tag_find(le.addr, le.addr, le.balance);
+   status = tag_find(le.addr, le.addr, le.balance, ADDR_TAG_LEN);
    printf("tag_find() returned %d  S/B 0\n", status);
    printf("le.addr = %-20.20s...\n", le.addr);
    printf("le.balance = %u\n", get32(le.balance));
@@ -60,7 +60,7 @@ int main()
    tag_free();
    tag_free();
    printf("tag_find('%-12.12s')\n", (char *) ADDR_TAG_PTR(le.addr));
-   status = tag_find(le.addr, le.addr, le.balance);
+   status = tag_find(le.addr, le.addr, le.balance, ADDR_TAG_LEN);
    printf("tag_find() returned %d  S/B 0\n", status);
    tag_buildidx();
 

--- a/src/txclean.c
+++ b/src/txclean.c
@@ -64,7 +64,9 @@ int txclean(void)
             memcpy(ADDR_TAG_PTR(addr), mtx->dst[j].tag, ADDR_TAG_LEN);
             mtx->zeros[j] = 0;
             /* If dst[j] tag not found, put error code in zeros[] array. */
-            if(tag_find(addr, NULL, NULL) != VEOK) mtx->zeros[j] = 1;
+            if(tag_find(addr, NULL, NULL, ADDR_TAG_LEN) != VEOK) {
+               mtx->zeros[j] = 1;
+            }
          }
       }
       count = fwrite(&tx, 1, sizeof(TXQENTRY), fpout);

--- a/src/txclean.c
+++ b/src/txclean.c
@@ -51,7 +51,7 @@ int txclean(void)
       count = fread(&tx, 1, sizeof(TXQENTRY), fp);
       if(count != sizeof(TXQENTRY)) break;  /* EOF */
       /* if src not in ledger continue; */
-      if(le_find(tx.src_addr, &src_le, NULL, 0) == FALSE) continue;
+      if(le_find(tx.src_addr, &src_le, NULL, TXADDRLEN) == FALSE) continue;
       if(cmp64(tx.tx_fee, Myfee) < 0) continue;  /* bad tx fee */
       /* check total overflow and balance */
       if(add64(tx.send_total, tx.change_total, total)) continue;

--- a/src/txval.c
+++ b/src/txval.c
@@ -80,7 +80,7 @@ int tx_val(TX *tx)
    }
 
    /* look up source address in ledger */
-   if(le_find(tx->src_addr, &src_le, NULL, 0) == FALSE) {
+   if(le_find(tx->src_addr, &src_le, NULL, TXADDRLEN) == FALSE) {
       if(Trace) plog("tx_val(): src_addr not in ledger");
       return 1;
    }


### PR DESCRIPTION
Enable partial address search with `le_find()`

*No fork required*
This commit enables compatibility for `le_find()` (in ledger.c) to perform either a full, or partial address search by replacing the original `mode` parameter with a `len` parameter so that `le_find()` can compare `len` number of bytes against the tx.src_addr supplied along with the OP_BALANCE request.

This has been tested as working on Ubuntu 20.04 LTS powered by 1vCPU/1GB NVME cloud instance, though I will encourage you to verify it yourself:
```
git clone --single-branch --branch feature/partial_address_search https://github.com/chrisdigity/mochimo.git
```