### PR TITLE
[F-26] fix(network): remove dead double-read in refresh_ipl() OP_FOUND proof

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -573,6 +573,7 @@ bad:
    /* get proof from tfile.dat (!!! (NTFTX - 1) ) */
    if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
    count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
+   /* TODO: add (count != NTFTX) check, see refresh_ipl() */
 
    /* build peerlist with Rplist (shuffled) */
    memset(plist, 0, sizeof(plist));
@@ -1039,13 +1040,11 @@ int refresh_ipl(void)
    } else goto FAIL;
    /* Check peer's chain weight against ours. */
    if(cmp256(node.tx.weight, Weight) < 0) {
-      /* get proof from tfile.dat */
-      memset(tx.buffer, 0, sizeof(tx.buffer));
-      if (sub64(Cblocknum, CL64_32(NTFTX), bnum)) memset(bnum, 0, 8);
+      /* get proof from tfile.dat, consistent with send_found() */
+      if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
       count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
+      if (count != NTFTX) goto FAIL;
       /* Send found message to low weight peer */
-      memset(tx.buffer, 0, sizeof(tx.buffer));
-      if (read_tfile(tx.buffer, Cblocknum, 54, "tfile.dat") == 0) goto FAIL;
       if(callserver(&node, ip) != VEOK) goto FAIL;
       memcpy(&node.tx, &tx, sizeof(TX));  /* copy in tfile proof */
       put16(node.tx.len, (word16) count * sizeof(BTRAILER));


### PR DESCRIPTION
Closes #114

## Summary
`refresh_ipl()` sends an `OP_FOUND` message to help lagging peers discover a heavier chain. The proof payload was malformed due to a dead double-read: the first `read_tfile()` result was immediately cleared and overwritten by a second read with different parameters, but the packet length was set from the first read's count. The receiver would reject the mismatched proof, silently breaking the background peer-help mechanism.

## Change
Removed the dead first read block and redundant `memset` calls. Replaced with a single `read_tfile()` matching `send_found()`'s proven pattern:

```c
// Before — dead code, mismatched length/content, wrong offset
memset(tx.buffer, 0, sizeof(tx.buffer));
if (sub64(Cblocknum, CL64_32(NTFTX), bnum)) memset(bnum, 0, 8);
count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
memset(tx.buffer, 0, sizeof(tx.buffer));
if (read_tfile(tx.buffer, Cblocknum, 54, "tfile.dat") == 0) goto FAIL;

// After — single read, correct offset, consistent with send_found()
if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
if (count != NTFTX) goto FAIL;
```

The `NTFTX - 1` offset produces an inclusive range of 54 trailers ending at `Cblocknum`, matching what the receiver's `contention()` expects when validating the proof against the advertised weight (stamped by `send_tx()` from the global `Weight`).

Added `count != NTFTX` check to skip the send on short or failed reads — the receiver would reject incomplete proof anyway, so this avoids a wasted network round trip.

Added a TODO comment in `send_found()` noting the same check should be added there.

## Testing
- Clean build with `-Wall -Werror -Wextra -Wpedantic`