### PR TITLE
[F-06] fix(sync,bup): replace system() calls with native C file operations

### DIFF
--- a/src/bup.c
+++ b/src/bup.c
@@ -22,6 +22,7 @@
 #include "error.h"
 #include "bval.h"
 #include "bcon.h"
+#include "util.h"
 
 /* external support */
 #include <string.h>
@@ -261,7 +262,9 @@ CLEANUP:
 
    /* ... combine transaction queues before a clean */
    if (fexists("txq1.dat")) {
-      system("cat txq1.dat >>txclean.dat 2>/dev/null");
+      if (fappend("txq1.dat", "txclean.dat") != 0) {
+         perrno("failed to append txq1.dat to txclean.dat");
+      }
       remove("txq1.dat");
       /* txq1.dat is empty now */
       Txcount = 0;

--- a/src/sync.c
+++ b/src/sync.c
@@ -22,6 +22,7 @@
 #include "error.h"
 #include "bval.h"
 #include "bup.h"
+#include "util.h"
 
 /* external support */
 #include "extthrd.h"
@@ -370,9 +371,12 @@ int syncup(word32 splitblock, word8 *txcblock, word32 peerip)
 
    /* Backup TFILE, Ledger, and blocks to split-tree directory. */
    pdebug("Backing up TFILE, ledger.dat, and blocks...");
-   system("mkdir -p split/");
-   system("cp tfile.dat split/");
-   system("cp ledger.dat split/");
+   if (mkdir_p(SPDIR) != 0
+      || fcopy("tfile.dat", SPDIR "/tfile.dat") != 0
+      || fcopy("ledger.dat", SPDIR "/ledger.dat") != 0) {
+      perrno("state backup failed");
+      goto badsyncup;
+   }
 
    put32(sblock + 4, 0);
    put32(sblock, splitblock);
@@ -467,9 +471,11 @@ badsyncup:
    /* Restore block chain from saved state after a bad re-sync attempt. */
    pdebug("bad sync: restoring saved state...");
    le_close();
-   system("mv split/tfile.dat .");
-   system("mv split/ledger.dat .");
-   system("rm -r split/");
+   if (rename(SPDIR "/tfile.dat", "tfile.dat") != 0)
+      perrno("failed to restore tfile.dat");
+   if (rename(SPDIR "/ledger.dat", "ledger.dat") != 0)
+      perrno("failed to restore ledger.dat");
+   rmdir_r(SPDIR);
    reset_chain();  /* reset Difficulty and others */
    le_open("ledger.dat");
    Insyncup = 0;

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,98 @@
+/**
+ * @file util.c
+ * @private
+ * @headerfile util.h <util.h>
+ * @brief Mochimo utility functions.
+ * @details File operation utilities not yet available in extended-c.
+ * These functions are candidates for migration to extended-c/src/extio.
+ * When migrated, remove this file and update includes accordingly.
+ * @copyright Adequate Systems LLC, 2025. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+ *
+ * @par Migration instructions for extended-c:
+ * 1. Add fappend() and rmdir_r() to extended-c/src/extio.c
+ * 2. Add prototypes to extended-c/src/extio.h
+ * 3. Remove this file (src/util.c) and its header (src/util.h)
+ * 4. Update any #include "util.h" to rely on extio.h instead
+*/
+
+/* include guard */
+#ifndef MOCHIMO_UTIL_C
+#define MOCHIMO_UTIL_C
+
+
+#include "util.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+/**
+ * Append the contents of one file to another.
+ * Opens source for reading and destination for appending.
+ * Creates destination if it does not exist.
+ * @param srcpath Path of the source file to read from
+ * @param dstpath Path of the destination file to append to
+ * @return 0 on success, or non-zero on error. Check errno for details.
+*/
+int fappend(const char *srcpath, const char *dstpath)
+{
+   char buf[BUFSIZ];
+   FILE *sfp, *dfp;
+   size_t nBytes;
+   int fd, ecode = -1;
+
+   /* open source file */
+   sfp = fopen(srcpath, "rb");
+   if (sfp != NULL) {
+      /* open destination file for append with restricted permissions */
+      fd = open(dstpath, O_WRONLY | O_CREAT | O_APPEND, 0600);
+      dfp = (fd != -1) ? fdopen(fd, "ab") : NULL;
+      if (dfp != NULL) {
+         /* transfer bytes in BUFSIZ chunks (set by stdio) */
+         while ((nBytes = fread(buf, 1, BUFSIZ, sfp))) {
+            if (nBytes > 0 && fwrite(buf, nBytes, 1, dfp) != 1) break;
+            if (nBytes < BUFSIZ) break;  /* EOF or ERROR */
+         }
+         /* if no file errors, set operation success (0) */
+         if (ferror(sfp) == 0 && ferror(dfp) == 0) ecode = 0;
+         fclose(dfp);
+      }
+      fclose(sfp);
+   }
+
+   return ecode;
+}  /* end fappend() */
+
+/**
+ * Remove a directory and all files within it (non-recursive).
+ * Only removes regular files within the directory; does not
+ * descend into subdirectories. Fails if subdirectories exist
+ * and are non-empty.
+ * @param dirpath Path of the directory to remove
+ * @return 0 on success, or non-zero on error. Check errno for details.
+*/
+int rmdir_r(const char *dirpath)
+{
+   DIR *dir;
+   struct dirent *entry;
+   char filepath[BUFSIZ];
+
+   dir = opendir(dirpath);
+   if (dir == NULL) return -1;
+   while ((entry = readdir(dir)) != NULL) {
+      if (strcmp(entry->d_name, ".") == 0) continue;
+      if (strcmp(entry->d_name, "..") == 0) continue;
+      snprintf(filepath, sizeof(filepath), "%s/%s", dirpath, entry->d_name);
+      remove(filepath);
+   }
+   closedir(dir);
+
+   return rmdir(dirpath);
+}  /* end rmdir_r() */
+
+/* end include guard */
+#endif

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,47 @@
+/**
+ * @file util.h
+ * @brief Mochimo utility functions.
+ * @details File operation utilities not yet available in extended-c.
+ * These functions are candidates for migration to extended-c/src/extio.
+ * When migrated, remove this file and update includes accordingly.
+ * @copyright Adequate Systems LLC, 2025. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+*/
+
+/* include guard */
+#ifndef MOCHIMO_UTIL_H
+#define MOCHIMO_UTIL_H
+
+/* C/C++ compatible function prototypes */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Append the contents of one file to another.
+ * Opens source for reading and destination for appending.
+ * Creates destination if it does not exist.
+ * @param srcpath Path of the source file to read from
+ * @param dstpath Path of the destination file to append to
+ * @return 0 on success, or non-zero on error. Check errno for details.
+ * @note Migration: add to extended-c/src/extio.h as fappend()
+ */
+int fappend(const char *srcpath, const char *dstpath);
+
+/**
+ * Remove a directory and all files within it (non-recursive).
+ * Only removes regular files within the directory; does not
+ * descend into subdirectories. Fails if subdirectories exist.
+ * @param dirpath Path of the directory to remove
+ * @return 0 on success, or non-zero on error. Check errno for details.
+ * @note Migration: add to extended-c/src/extio.h as rmdir_r()
+ *       Consider adding recursive subdirectory support if needed.
+ */
+int rmdir_r(const char *dirpath);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+/* end include guard */
+#endif


### PR DESCRIPTION
Closes #108

## Summary
Replaced 7 shell-spawning `system()` calls in `syncup()` and `b_update()` with native C file operations. The originals had no return-value checks — disk full, permission errors, or missing files were silently ignored.

## Changes

**syncup() backup** — `mkdir -p`/`cp` replaced with `mkdir_p()`/`fcopy()`:
- Now checks all return values; aborts to `badsyncup` on failure
- Previously would continue into destructive operations without a confirmed backup

**syncup() restore** — `mv`/`rm -r` replaced with `rename()`/`rmdir_r()`:
- Logs failures via `perrno()` but continues (best-effort recovery)
- `rename()` is atomic on same filesystem, matching POSIX `mv` behavior

**b_update() txq append** — `cat >>` replaced with `fappend()`:
- Logs failure; continues to `remove("txq1.dat")` matching original behavior

## New utility functions (src/util.h, src/util.c)
- `fappend()` — file append, no equivalent in extended-c
- `rmdir_r()` — single-level recursive directory removal, no equivalent in extended-c
- Both documented for future migration to the extended-c library

## Testing
- Clean build with `-Wall -Werror -Wextra -Wpedantic`
- 63-test harness verifying behavioral parity posted to issue #108
- Node startup confirmed with native operations