### PR TITLE
[F-12] fix(network): replace system(dd) with native C in send_tf()

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -23,6 +23,7 @@
 
 /* external support */
 #include <string.h>
+#include <fcntl.h>
 #include "exttime.h"
 #include "extthrd.h"
 #include "extmath.h"
@@ -492,7 +493,10 @@ int send_tf(NODE *np)
 {
    int status;
    word32 first, count;
-   char cmd[128], fname[32];
+   char fname[32];
+   BTRAILER bt;
+   FILE *ifp, *ofp;
+   word32 j;
 
    sprintf(fname, "tf%u.tmp", (int) getpid());
 
@@ -500,10 +504,28 @@ int send_tf(NODE *np)
    count = get32(&np->tx.blocknum[4]);  /* count of trailers to send */
 
    /* limit tfile extract to 1000 trailers */
-   if(count > 1000) return VERROR;
-   sprintf(cmd, "dd if=tfile.dat of=%s bs=%u skip=%u count=%u 2>/dev/null",
-                fname, (int) sizeof(BTRAILER), first, count);
-   system(cmd);
+   if (count > 1000) return VERROR;
+
+   /* extract trailers from tfile.dat to temp file */
+   ifp = fopen("tfile.dat", "rb");
+   if (ifp == NULL) return VERROR;
+   if (fseek64(ifp, (long long) first * sizeof(BTRAILER), SEEK_SET) != 0) {
+      fclose(ifp);
+      return VERROR;
+   }
+   {  int fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+   ofp = (fd != -1) ? fdopen(fd, "wb") : NULL; }
+   if (ofp == NULL) {
+      fclose(ifp);
+      return VERROR;
+   }
+   for (j = 0; j < count && Running; j++) {
+      if (fread(&bt, sizeof(BTRAILER), 1, ifp) != 1) break;
+      if (fwrite(&bt, sizeof(BTRAILER), 1, ofp) != 1) break;
+   }
+   fclose(ifp);
+   fclose(ofp);
+
    status = send_file(np, fname);  /* returns VEOK or VERROR */
    remove(fname);
    return status;


### PR DESCRIPTION
Closes #105

## Summary
`send_tf()` constructed a `dd` shell command with a peer-controlled skip offset and executed it via `system()`. Replaced with native `fseek64`/`fread`/`fwrite`.

## Change
```c
// Before — shell command with peer-controlled parameter
sprintf(cmd, "dd if=tfile.dat of=%s bs=%u skip=%u count=%u 2>/dev/null",
             fname, (int) sizeof(BTRAILER), first, count);
system(cmd);

// After — native file I/O with shutdown awareness
ifp = fopen("tfile.dat", "rb");
fseek64(ifp, (long long) first * sizeof(BTRAILER), SEEK_SET);
ofp = fopen(fname, "wb");
for (j = 0; j < count && Running; j++) {
   if (fread(&bt, sizeof(BTRAILER), 1, ifp) != 1) break;
   if (fwrite(&bt, sizeof(BTRAILER), 1, ofp) != 1) break;
}
```

## Why
- Eliminates shell process overhead (2 processes per request, up to 37 concurrent connections)
- Removes peer-controlled values from shell command strings
- Adds explicit error handling on open/seek/read/write
- Checks `Running` flag between iterations for clean shutdown
- Identical output for all inputs including past-EOF and count=0

## Testing
- Clean build with `-Wall -Werror -Wextra -Wpedantic`
- **Offline test harness** (63 tests): byte-for-byte parity verified between `system(dd)` and native C across normal operations, edge cases, boundary conditions, permission errors, and real tfile.dat. Posted to issue #105.
- **Live integration test** (25 tests): connected to a running node via OP_TF protocol, received tfile data through the real production code path, compared against direct disk reads — all byte-identical. Covers start/middle/tip/max-count/single/last/partial/EOF scenarios.