### PR TITLE
[F-20] fix(bup,sync): add return-value checks on external script system() calls

### DIFF
--- a/src/bup.c
+++ b/src/bup.c
@@ -252,7 +252,9 @@ int b_update(char *fname)
    mergepinklists();
    /* trigger synchronous external update - if available */
    if (Ininit == 0 && fexists("../update-external.sh")) {
-      system("../update-external.sh");
+      if (system("../update-external.sh") != 0) {
+         pwarn("../update-external.sh returned error");
+      }
    }
 
 CLEANUP:

--- a/src/sync.c
+++ b/src/sync.c
@@ -324,7 +324,9 @@ int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
    /* Shell script in /bin directory */
    if(Exportflag && fexists("../init-external.sh")) {
      plog("Calling ../init-external.sh\n");  /* first time call */
-     system("../init-external.sh");
+     if (system("../init-external.sh") != 0) {
+        pwarn("../init-external.sh returned error");
+     }
    }
 
    if(!Running) resign("quorum update");


### PR DESCRIPTION
Closes #109

## Summary
The two external script hooks — `../update-external.sh` (called on every block update) and `../init-external.sh` (called after resync) — had no return-value checks on their `system()` calls. A failed script was silently ignored.

## Change
Added `system() != 0` check with `pwarn()` logging at both sites. The scripts remain invoked via `system()` since their purpose is to run external programs.

```c
// Before
system("../update-external.sh");

// After
if (system("../update-external.sh") != 0) {
   pwarn("../update-external.sh returned error");
}
```

The relative path and `fexists()` pre-check are unchanged — the audit noted these as concerns, but they are by-design (the scripts are optional hooks located relative to the node's working directory).

## Testing
- Clean build with `-Wall -Werror -Wextra -Wpedantic`