### PR TITLE
Audit fixes batch 6: system() replacements, refresh_ipl fix, external script checks

### DIFF
--- a/src/bup.c
+++ b/src/bup.c
@@ -252,7 +252,9 @@ int b_update(char *fname)
    mergepinklists();
    /* trigger synchronous external update - if available */
    if (Ininit == 0 && fexists("../update-external.sh")) {
-      system("../update-external.sh");
+      if (system("../update-external.sh") != 0) {
+         pwarn("../update-external.sh returned error");
+      }
    }
 
 CLEANUP:

--- a/src/bup.c
+++ b/src/bup.c
@@ -22,6 +22,7 @@
 #include "error.h"
 #include "bval.h"
 #include "bcon.h"
+#include "util.h"
 
 /* external support */
 #include <string.h>
@@ -261,7 +262,9 @@ CLEANUP:
 
    /* ... combine transaction queues before a clean */
    if (fexists("txq1.dat")) {
-      system("cat txq1.dat >>txclean.dat 2>/dev/null");
+      if (fappend("txq1.dat", "txclean.dat") != 0) {
+         perrno("failed to append txq1.dat to txclean.dat");
+      }
       remove("txq1.dat");
       /* txq1.dat is empty now */
       Txcount = 0;

--- a/src/network.c
+++ b/src/network.c
@@ -23,6 +23,7 @@
 
 /* external support */
 #include <string.h>
+#include <fcntl.h>
 #include "exttime.h"
 #include "extthrd.h"
 #include "extmath.h"
@@ -492,7 +493,10 @@ int send_tf(NODE *np)
 {
    int status;
    word32 first, count;
-   char cmd[128], fname[32];
+   char fname[32];
+   BTRAILER bt;
+   FILE *ifp, *ofp;
+   word32 j;
 
    sprintf(fname, "tf%u.tmp", (int) getpid());
 
@@ -500,10 +504,28 @@ int send_tf(NODE *np)
    count = get32(&np->tx.blocknum[4]);  /* count of trailers to send */
 
    /* limit tfile extract to 1000 trailers */
-   if(count > 1000) return VERROR;
-   sprintf(cmd, "dd if=tfile.dat of=%s bs=%u skip=%u count=%u 2>/dev/null",
-                fname, (int) sizeof(BTRAILER), first, count);
-   system(cmd);
+   if (count > 1000) return VERROR;
+
+   /* extract trailers from tfile.dat to temp file */
+   ifp = fopen("tfile.dat", "rb");
+   if (ifp == NULL) return VERROR;
+   if (fseek64(ifp, (long long) first * sizeof(BTRAILER), SEEK_SET) != 0) {
+      fclose(ifp);
+      return VERROR;
+   }
+   {  int fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+   ofp = (fd != -1) ? fdopen(fd, "wb") : NULL; }
+   if (ofp == NULL) {
+      fclose(ifp);
+      return VERROR;
+   }
+   for (j = 0; j < count && Running; j++) {
+      if (fread(&bt, sizeof(BTRAILER), 1, ifp) != 1) break;
+      if (fwrite(&bt, sizeof(BTRAILER), 1, ofp) != 1) break;
+   }
+   fclose(ifp);
+   fclose(ofp);
+
    status = send_file(np, fname);  /* returns VEOK or VERROR */
    remove(fname);
    return status;

--- a/src/network.c
+++ b/src/network.c
@@ -573,6 +573,7 @@ bad:
    /* get proof from tfile.dat (!!! (NTFTX - 1) ) */
    if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
    count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
+   /* TODO: add (count != NTFTX) check, see refresh_ipl() */
 
    /* build peerlist with Rplist (shuffled) */
    memset(plist, 0, sizeof(plist));
@@ -1039,13 +1040,11 @@ int refresh_ipl(void)
    } else goto FAIL;
    /* Check peer's chain weight against ours. */
    if(cmp256(node.tx.weight, Weight) < 0) {
-      /* get proof from tfile.dat */
-      memset(tx.buffer, 0, sizeof(tx.buffer));
-      if (sub64(Cblocknum, CL64_32(NTFTX), bnum)) memset(bnum, 0, 8);
+      /* get proof from tfile.dat, consistent with send_found() */
+      if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
       count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
+      if (count != NTFTX) goto FAIL;
       /* Send found message to low weight peer */
-      memset(tx.buffer, 0, sizeof(tx.buffer));
-      if (read_tfile(tx.buffer, Cblocknum, 54, "tfile.dat") == 0) goto FAIL;
       if(callserver(&node, ip) != VEOK) goto FAIL;
       memcpy(&node.tx, &tx, sizeof(TX));  /* copy in tfile proof */
       put16(node.tx.len, (word16) count * sizeof(BTRAILER));

--- a/src/sync.c
+++ b/src/sync.c
@@ -324,7 +324,9 @@ int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
    /* Shell script in /bin directory */
    if(Exportflag && fexists("../init-external.sh")) {
      plog("Calling ../init-external.sh\n");  /* first time call */
-     system("../init-external.sh");
+     if (system("../init-external.sh") != 0) {
+        pwarn("../init-external.sh returned error");
+     }
    }
 
    if(!Running) resign("quorum update");

--- a/src/sync.c
+++ b/src/sync.c
@@ -22,6 +22,7 @@
 #include "error.h"
 #include "bval.h"
 #include "bup.h"
+#include "util.h"
 
 /* external support */
 #include "extthrd.h"
@@ -370,9 +371,12 @@ int syncup(word32 splitblock, word8 *txcblock, word32 peerip)
 
    /* Backup TFILE, Ledger, and blocks to split-tree directory. */
    pdebug("Backing up TFILE, ledger.dat, and blocks...");
-   system("mkdir -p split/");
-   system("cp tfile.dat split/");
-   system("cp ledger.dat split/");
+   if (mkdir_p(SPDIR) != 0
+      || fcopy("tfile.dat", SPDIR "/tfile.dat") != 0
+      || fcopy("ledger.dat", SPDIR "/ledger.dat") != 0) {
+      perrno("state backup failed");
+      goto badsyncup;
+   }
 
    put32(sblock + 4, 0);
    put32(sblock, splitblock);
@@ -467,9 +471,11 @@ badsyncup:
    /* Restore block chain from saved state after a bad re-sync attempt. */
    pdebug("bad sync: restoring saved state...");
    le_close();
-   system("mv split/tfile.dat .");
-   system("mv split/ledger.dat .");
-   system("rm -r split/");
+   if (rename(SPDIR "/tfile.dat", "tfile.dat") != 0)
+      perrno("failed to restore tfile.dat");
+   if (rename(SPDIR "/ledger.dat", "ledger.dat") != 0)
+      perrno("failed to restore ledger.dat");
+   rmdir_r(SPDIR);
    reset_chain();  /* reset Difficulty and others */
    le_open("ledger.dat");
    Insyncup = 0;

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,98 @@
+/**
+ * @file util.c
+ * @private
+ * @headerfile util.h <util.h>
+ * @brief Mochimo utility functions.
+ * @details File operation utilities not yet available in extended-c.
+ * These functions are candidates for migration to extended-c/src/extio.
+ * When migrated, remove this file and update includes accordingly.
+ * @copyright Adequate Systems LLC, 2025. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+ *
+ * @par Migration instructions for extended-c:
+ * 1. Add fappend() and rmdir_r() to extended-c/src/extio.c
+ * 2. Add prototypes to extended-c/src/extio.h
+ * 3. Remove this file (src/util.c) and its header (src/util.h)
+ * 4. Update any #include "util.h" to rely on extio.h instead
+*/
+
+/* include guard */
+#ifndef MOCHIMO_UTIL_C
+#define MOCHIMO_UTIL_C
+
+
+#include "util.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+/**
+ * Append the contents of one file to another.
+ * Opens source for reading and destination for appending.
+ * Creates destination if it does not exist.
+ * @param srcpath Path of the source file to read from
+ * @param dstpath Path of the destination file to append to
+ * @return 0 on success, or non-zero on error. Check errno for details.
+*/
+int fappend(const char *srcpath, const char *dstpath)
+{
+   char buf[BUFSIZ];
+   FILE *sfp, *dfp;
+   size_t nBytes;
+   int fd, ecode = -1;
+
+   /* open source file */
+   sfp = fopen(srcpath, "rb");
+   if (sfp != NULL) {
+      /* open destination file for append with restricted permissions */
+      fd = open(dstpath, O_WRONLY | O_CREAT | O_APPEND, 0600);
+      dfp = (fd != -1) ? fdopen(fd, "ab") : NULL;
+      if (dfp != NULL) {
+         /* transfer bytes in BUFSIZ chunks (set by stdio) */
+         while ((nBytes = fread(buf, 1, BUFSIZ, sfp))) {
+            if (nBytes > 0 && fwrite(buf, nBytes, 1, dfp) != 1) break;
+            if (nBytes < BUFSIZ) break;  /* EOF or ERROR */
+         }
+         /* if no file errors, set operation success (0) */
+         if (ferror(sfp) == 0 && ferror(dfp) == 0) ecode = 0;
+         fclose(dfp);
+      }
+      fclose(sfp);
+   }
+
+   return ecode;
+}  /* end fappend() */
+
+/**
+ * Remove a directory and all files within it (non-recursive).
+ * Only removes regular files within the directory; does not
+ * descend into subdirectories. Fails if subdirectories exist
+ * and are non-empty.
+ * @param dirpath Path of the directory to remove
+ * @return 0 on success, or non-zero on error. Check errno for details.
+*/
+int rmdir_r(const char *dirpath)
+{
+   DIR *dir;
+   struct dirent *entry;
+   char filepath[BUFSIZ];
+
+   dir = opendir(dirpath);
+   if (dir == NULL) return -1;
+   while ((entry = readdir(dir)) != NULL) {
+      if (strcmp(entry->d_name, ".") == 0) continue;
+      if (strcmp(entry->d_name, "..") == 0) continue;
+      snprintf(filepath, sizeof(filepath), "%s/%s", dirpath, entry->d_name);
+      remove(filepath);
+   }
+   closedir(dir);
+
+   return rmdir(dirpath);
+}  /* end rmdir_r() */
+
+/* end include guard */
+#endif

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,47 @@
+/**
+ * @file util.h
+ * @brief Mochimo utility functions.
+ * @details File operation utilities not yet available in extended-c.
+ * These functions are candidates for migration to extended-c/src/extio.
+ * When migrated, remove this file and update includes accordingly.
+ * @copyright Adequate Systems LLC, 2025. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+*/
+
+/* include guard */
+#ifndef MOCHIMO_UTIL_H
+#define MOCHIMO_UTIL_H
+
+/* C/C++ compatible function prototypes */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Append the contents of one file to another.
+ * Opens source for reading and destination for appending.
+ * Creates destination if it does not exist.
+ * @param srcpath Path of the source file to read from
+ * @param dstpath Path of the destination file to append to
+ * @return 0 on success, or non-zero on error. Check errno for details.
+ * @note Migration: add to extended-c/src/extio.h as fappend()
+ */
+int fappend(const char *srcpath, const char *dstpath);
+
+/**
+ * Remove a directory and all files within it (non-recursive).
+ * Only removes regular files within the directory; does not
+ * descend into subdirectories. Fails if subdirectories exist.
+ * @param dirpath Path of the directory to remove
+ * @return 0 on success, or non-zero on error. Check errno for details.
+ * @note Migration: add to extended-c/src/extio.h as rmdir_r()
+ *       Consider adding recursive subdirectory support if needed.
+ */
+int rmdir_r(const char *dirpath);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+/* end include guard */
+#endif


### PR DESCRIPTION
## Summary
Sixth batch of audit remediation. Eliminates all shell-spawning `system()` calls for file operations, fixes a silently broken peer-help mechanism, and adds error logging to external script hooks.

### Changes

- **[F-06] sync.c, bup.c, util.c/h** — Replace `system()` calls for backup/restore/append with native C using `fcopy()`, `mkdir_p()`, `rename()`, `fappend()`, `rmdir_r()`. Adds error detection where none existed. New `util.c`/`util.h` for functions not yet in extended-c. (Closes #108)

- **[F-12] network.c** — Replace `system("dd ...")` in `send_tf()` with native `fseek64`/`fread`/`fwrite`. Removes peer-controlled values from shell command strings. Adds `Running` check for clean shutdown. Verified with 63 offline tests and 25 live integration tests via OP_TF protocol. (Closes #105)

- **[F-26] network.c** — Fix silently broken `refresh_ipl()` OP_FOUND proof. Dead double-read pattern caused mismatched length/content in proof packets, so background peer-help never worked. Replaced with single read matching `send_found()`. (Closes #114)

- **[F-20] bup.c, sync.c** — Add return-value checks and `pwarn()` logging on external script `system()` calls (`update-external.sh`, `init-external.sh`). (Closes #109)

### Testing
- All changes build clean with `-Wall -Werror -Wextra -Wpedantic` (GCC 13)
- F-06: 63-test harness verifying behavioral parity (posted to #108)
- F-12: 63 offline tests + 25 live integration tests via OP_TF (posted to #105)
- 5 files changed, 198 insertions, 19 deletions