### PR TITLE
[F-29] fix(network): reject oversized peer list responses in get_ipl()

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -748,10 +748,18 @@ int get_ipl(NODE *np, word32 ip)
       /* send OP_GET_IPL and receive single packet response */
       ecode = send_op(np, OP_GET_IPL);
       if (ecode == VEOK) ecode = recv_tx(np, STD_TIMEOUT);
+      /* reject oversized peer lists (DoS mitigation) */
+      if (ecode == VEOK
+         && get16(np->tx.len) > RPLISTLEN * sizeof(word32)) {
+         ecode = VEBAD;
+      }
       /* cleanup */
       sock_close(np->sd);
       np->sd = INVALID_SOCKET;
    }
+   /* TODO: received peer IPs should be treated as unverified candidates
+    * until confirmed as real nodes, rather than added directly to the
+    * scan/recent peer lists. See: https://github.com/mochimodev/mochimo/issues/107 */
 
    return ecode;
 }  /* end get_ipl() */


### PR DESCRIPTION
Closes #107

## Summary
A peer responding to `OP_GET_IPL` could include up to 65535 bytes of IP data in the response (the `word16 len` field maximum). While the consumer loop in `scan_quorum()` caps `netplistidx` at 1024, the excess data causes unnecessary iteration — a remote DoS vector for wasting CPU during peer discovery.

## Change
Added a bounds check in `get_ipl()` rejecting responses where `len > RPLISTLEN * sizeof(word32)` (256 bytes = 64 IPs) — the maximum a legitimate node would ever send via `send_ipl()`.

The original audit also flagged missing opcode validation, but analysis showed this adds minimal value: the chain-state fields (`weight`, `cblockhash`, `cblock`) are filled by `send_tx()` on the responding side regardless of opcode, so a malicious peer could fabricate them in a legitimate `OP_SEND_IPL` response just as easily.

Added a TODO noting that received peer IPs should be treated as unverified candidates until confirmed as real nodes, rather than added directly to scan/recent peer lists.

## Testing
- Clean build with `-Wall -Werror -Wextra -Wpedantic`