### PR TITLE
feat(peer): provisional peer verification subsystem

### DIFF
--- a/src/bin/mochimo.c
+++ b/src/bin/mochimo.c
@@ -687,6 +687,11 @@ int server(int reuse_addr)
 
    remove("vstart.lck");  /* signal Verisimility that we are up. */
 
+   /* start provisional peer verification thread */
+   if (start_provisional_verifier() != 0) {
+      pwarn("failed to start provisional peer verifier");
+   }
+
    /*
     * Main server loop.
     */
@@ -1010,6 +1015,7 @@ int server(int reuse_addr)
 
       if(Ltime >= ipltime) {
          refresh_ipl();  /* refresh ip list */
+         harvest_provisional();  /* promote verified provisional peers */
          ipltime = Ltime + (rand16() % 300) + 10;
       }
 
@@ -1025,6 +1031,7 @@ int server(int reuse_addr)
 
    /* cleanup */
    plog("Server exiting, please wait...");
+   stop_provisional_verifier();
    sock_close(lsd);  /* close listening socket */
 
    return 0;

--- a/src/network.c
+++ b/src/network.c
@@ -944,7 +944,7 @@ int scan_quorum
 (word32 quorum[], word32 qlen, void *hash, void *weight, void *bnum)
 {
    NODE node;
-   word32 peer;
+   word32 peer, source;
    word32 scanidx = 0;
    word32 qcount = 0;
    word32 netplist[1024];
@@ -970,7 +970,7 @@ int scan_quorum
       pdebug("scan index %u/%u...", scanidx, netplistidx);
 
       /* prepare parallel processing scope */
-      OMP_PARALLEL_(for private(node, peer, len, ipstr) num_threads(qlen))
+      OMP_PARALLEL_(for private(node, peer, source, len, ipstr) num_threads(qlen))
       for (word32 idx = scanidx; idx < netplistidx; idx++) {
          /* get IP list from peer */
          peer = netplist[idx];
@@ -1004,17 +1004,20 @@ int scan_quorum
                }  /* end if higher or same chain */
             }  /* end OMP_CRITICAL_() */
             /* inspect peer list */
+            source = netplist[idx]; /* save source before overwrite */
             for (len = 0, result = 0; len < get16(node.tx.len); len += 4) {
                if (netplistidx >= 1024) break;
                /* check (and recognise contribution of) valid peers */
                peer = get32(&node.tx.buffer[len]);
                if (peer == 0 || pinklisted(peer)) continue;
                if (!isprivate(peer) || !Noprivate) result++;
-               /* add to network list */
+               /* add to network list for immediate scanning */
                OMP_CRITICAL_()
                if (addpeer(peer, netplist, 1024, &netplistidx)) {
                   pdebug("Added %s to netplist", ntoa(&peer, ipstr));
                }
+               /* add to provisional list for verification */
+               addprovisional(peer, source);
             }
             /* add peer to recent peers on contribution */
             if (result) {
@@ -1059,13 +1062,12 @@ int refresh_ipl(void)
       ip = Rplist[rand16() % RPLISTLEN];
    if(ip == 0) goto FAIL;
    if (get_ipl(&node, ip) == VEOK) {
-      /* add iplist to recent peers */
+      /* add iplist to provisional peers for verification */
       len = get16(node.tx.len);
       for(j = 0; len > 0; j += 4, len -= 4) {
          peer = get32(node.tx.buffer + j);
          if (peer == 0) continue;
-         if (Rplist[RPLISTLEN - 1]) break;
-         addrecent(peer);
+         addprovisional(peer, ip);
       }
    } else goto FAIL;
    /* Check peer's chain weight against ours. */

--- a/src/peer.c
+++ b/src/peer.c
@@ -12,11 +12,15 @@
 #include "peer.h"
 
 /* internal support */
+#include "network.h"
 #include "error.h"
 
 /* external support */
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
+#include "exttime.h"
+#include "extthrd.h"
 #include "extlib.h"
 #include "extinet.h"
 
@@ -344,6 +348,252 @@ void purge_epoch(void)
    memset(Epinklist, 0, sizeof(Epinklist));
    Epinkidx = 0;
 }
+
+/* ----------------------------------------------------------------
+ * Provisional Peer Management
+ * ---------------------------------------------------------------- */
+
+/* provisional peer list and synchronization */
+static PROVPEER Provlist[PROVPEERSLEN];
+static word32 Provcount = 0;
+static RWLock Provlock = RWLOCK_INITIALIZER;
+
+/* verification thread state */
+static Thread Provthread;
+static volatile int Provrunning = 0;
+
+/**
+ * @private
+ * Check source reputation within the recent time window.
+ * Must be called with at least a read lock held.
+ * @param source_ip IP of the source to evaluate
+ * @param now Current time
+ * @return 1 if source has bad reputation, 0 if acceptable
+ */
+static int source_is_bad(word32 source_ip, word32 now)
+{
+   word32 i, total, failures, last_attempt;
+
+   total = failures = 0;
+   for (i = 0; i < Provcount; i++) {
+      if (Provlist[i].source_ip != source_ip) continue;
+      if (Provlist[i].status == PROVSTATUS_EXPIRED) {
+         /* derive last_attempt from next_attempt and fail_count */
+         last_attempt = Provlist[i].next_attempt
+            - (PROVBACKOFF * Provlist[i].fail_count);
+         /* only count entries within the reputation window */
+         if (now > last_attempt && (now - last_attempt) > PROVREPUTIME) {
+            continue;
+         }
+         total++;
+         failures++;
+      } else if (Provlist[i].status == PROVSTATUS_PENDING) {
+         total++;
+      }
+   }
+   if (total < PROVREPUTHR) return 0;
+   if ((failures * 100 / total) >= PROVREPUFAIL) return 1;
+   return 0;
+}
+
+/**
+ * Add an IP to the provisional peer list.
+ * Deduplicates against existing provisional entries and Rplist.
+ * Checks source reputation -- silently drops IPs from sources with
+ * high failure rates in the recent time window.
+ * @param ip Candidate peer IP address
+ * @param source_ip IP of the peer that advertised this candidate
+ * @return 0 on success (appended or deduplicated), -1 if list full
+ */
+int addprovisional(word32 ip, word32 source_ip)
+{
+   word32 i, now;
+
+   if (ip == 0) return 0;
+
+   rwlock_wrlock(&Provlock);
+
+   /* check if already in provisional list */
+   for (i = 0; i < Provcount; i++) {
+      if (Provlist[i].ip == ip) {
+         rwlock_wrunlock(&Provlock);
+         return 0;  /* duplicate */
+      }
+   }
+
+   /* check if already in Rplist */
+   if (search32(ip, Rplist, RPLISTLEN) != NULL) {
+      rwlock_wrunlock(&Provlock);
+      return 0;  /* already a known peer */
+   }
+
+   /* check source reputation */
+   now = (word32) time(NULL);
+   if (source_is_bad(source_ip, now)) {
+      rwlock_wrunlock(&Provlock);
+      return 0;  /* source has bad reputation */
+   }
+
+   /* check capacity */
+   if (Provcount >= PROVPEERSLEN) {
+      rwlock_wrunlock(&Provlock);
+      return -1;  /* list full */
+   }
+
+   /* append new entry */
+   memset(&Provlist[Provcount], 0, sizeof(PROVPEER));
+   Provlist[Provcount].ip = ip;
+   Provlist[Provcount].source_ip = source_ip;
+   Provlist[Provcount].status = PROVSTATUS_PENDING;
+   Provcount++;
+
+   rwlock_wrunlock(&Provlock);
+   return 0;
+}  /* end addprovisional() */
+
+/**
+ * Harvest verified peers from the provisional list into Rplist.
+ * Scans for entries with status=VERIFIED, calls addrecent() for each,
+ * and clears them. Also compacts expired entries to reclaim space.
+ * @return Number of peers promoted, or -1 on error
+ */
+int harvest_provisional(void)
+{
+   word32 i, j, promoted;
+
+   rwlock_wrlock(&Provlock);
+
+   promoted = 0;
+   for (i = 0; i < Provcount; i++) {
+      if (Provlist[i].status == PROVSTATUS_VERIFIED) {
+         addrecent(Provlist[i].ip);
+         promoted++;
+         Provlist[i].status = PROVSTATUS_EXPIRED;  /* mark for removal */
+      }
+   }
+
+   /* compact: remove expired entries by shifting remaining down */
+   j = 0;
+   for (i = 0; i < Provcount; i++) {
+      if (Provlist[i].status == PROVSTATUS_EXPIRED) continue;
+      if (i != j) memcpy(&Provlist[j], &Provlist[i], sizeof(PROVPEER));
+      j++;
+   }
+   Provcount = j;
+
+   rwlock_wrunlock(&Provlock);
+   return (int) promoted;
+}  /* end harvest_provisional() */
+
+/**
+ * @private
+ * Verification thread routine.
+ * Processes pending entries in batches, sleeping between passes. */
+static ThreadProc provpeer_thread(void *arg)
+{
+   NODE node;
+   word32 i, ip, now, batch;
+   int ecode;
+
+   (void) arg;
+
+   while (Provrunning && Running) {
+      batch = 0;
+
+      for (i = 0; i < PROVPEERSLEN && batch < PROVBATCHSIZE; i++) {
+         if (!Provrunning || !Running) break;
+
+         /* read lock to check entry */
+         rwlock_rdlock(&Provlock);
+         if (i >= Provcount) {
+            rwlock_rdunlock(&Provlock);
+            break;
+         }
+         if (Provlist[i].status != PROVSTATUS_PENDING) {
+            rwlock_rdunlock(&Provlock);
+            continue;
+         }
+         now = (word32) time(NULL);
+         if (Provlist[i].next_attempt > now) {
+            rwlock_rdunlock(&Provlock);
+            continue;
+         }
+         ip = Provlist[i].ip;
+         rwlock_rdunlock(&Provlock);
+
+         /* attempt connection (blocking -- OK in background thread) */
+         memset(&node, 0, sizeof(NODE));
+         ecode = callserver(&node, ip);
+         if (ecode == VEOK) {
+            sock_close(node.sd);
+            node.sd = INVALID_SOCKET;
+         }
+
+         /* update entry with result */
+         rwlock_wrlock(&Provlock);
+         if (i < Provcount && Provlist[i].ip == ip) {
+            if (ecode == VEOK) {
+               Provlist[i].status = PROVSTATUS_VERIFIED;
+            } else {
+               Provlist[i].fail_count++;
+               now = (word32) time(NULL);
+               Provlist[i].next_attempt =
+                  now + (PROVBACKOFF * Provlist[i].fail_count);
+               if (Provlist[i].fail_count >= PROVMAXFAILS) {
+                  Provlist[i].status = PROVSTATUS_EXPIRED;
+               }
+            }
+         }
+         rwlock_wrunlock(&Provlock);
+         batch++;
+      }  /* end for */
+
+      /* sleep between passes (check Running every second) */
+      for (i = 0; i < 30 && Provrunning && Running; i++) {
+         millisleep(1000);
+      }
+   }  /* end while */
+
+   return 0;
+}  /* end provpeer_thread() */
+
+/**
+ * Start the background provisional peer verification thread.
+ * The thread processes up to PROVBATCHSIZE entries per pass,
+ * attempting callserver() on each pending entry whose
+ * next_attempt time has passed. Sleeps between passes.
+ * @return 0 on success, -1 on error
+ */
+int start_provisional_verifier(void)
+{
+   if (Provrunning) return 0;  /* already running */
+   Provrunning = 1;
+   if (thread_create(&Provthread, provpeer_thread, NULL) != 0) {
+      Provrunning = 0;
+      return -1;
+   }
+   return 0;
+}  /* end start_provisional_verifier() */
+
+/**
+ * Stop the background provisional peer verification thread.
+ * Signals the thread to exit and waits for it to finish. */
+void stop_provisional_verifier(void)
+{
+   if (!Provrunning) return;
+   Provrunning = 0;
+   thread_join(Provthread);
+}  /* end stop_provisional_verifier() */
+
+/**
+ * Clear the entire provisional peer list. */
+void purge_provisional(void)
+{
+   rwlock_wrlock(&Provlock);
+   memset(Provlist, 0, sizeof(Provlist));
+   Provcount = 0;
+   rwlock_wrunlock(&Provlock);
+}  /* end purge_provisional() */
 
 /* end include guard */
 #endif

--- a/src/peer.h
+++ b/src/peer.h
@@ -46,6 +46,13 @@ int epinklist(word32 ip);
 void mergepinklists(void);
 void purge_epoch(void);
 
+/* provisional peer management */
+int addprovisional(word32 ip, word32 source_ip);
+int harvest_provisional(void);
+int start_provisional_verifier(void);
+void stop_provisional_verifier(void);
+void purge_provisional(void);
+
 #ifdef __cplusplus
 }  /* end extern "C" */
 #endif

--- a/src/test/peer-provisional.c
+++ b/src/test/peer-provisional.c
@@ -1,0 +1,165 @@
+/**
+ * @file peer-provisional.c
+ * @brief Unit tests for provisional peer management.
+ *
+ * Tests addprovisional(), harvest_provisional(), source reputation,
+ * thread lifecycle, capacity limits, and deduplication.
+ */
+
+#include "_assert.h"
+#include "peer.h"
+#include "global.h"
+#include "extthrd.h"
+#include "exttime.h"
+#include "extlib.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+int main()
+{
+   word32 i;
+   int rc, promoted;
+
+   /* init globals needed by peer functions */
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+   Running = 1;
+   Dstport = 2095;
+   srand16(12345, 67890, 11111);
+
+   /* ---- basic add and dedup ---- */
+
+   purge_provisional();
+
+   rc = addprovisional(0x01020304, 0x0A0B0C0D);
+   ASSERT_EQ(rc, 0);
+
+   rc = addprovisional(0x05060708, 0x0A0B0C0D);
+   ASSERT_EQ(rc, 0);
+
+   /* duplicate should be deduplicated (returns 0) */
+   rc = addprovisional(0x01020304, 0x0A0B0C0D);
+   ASSERT_EQ(rc, 0);
+
+   /* zero IP should be silently dropped */
+   rc = addprovisional(0, 0x0A0B0C0D);
+   ASSERT_EQ(rc, 0);
+
+   /* ---- dedup against Rplist ---- */
+
+   purge_provisional();
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+   addrecent(0xAABBCCDD);
+
+   /* IP already in Rplist should be dropped */
+   rc = addprovisional(0xAABBCCDD, 0x01010101);
+   ASSERT_EQ(rc, 0);
+
+   /* different IP should succeed */
+   rc = addprovisional(0x11223344, 0x01010101);
+   ASSERT_EQ(rc, 0);
+
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+
+   /* ---- harvest with no verified entries ---- */
+
+   purge_provisional();
+   addprovisional(0x01010101, 0xAAAAAAAA);
+   addprovisional(0x02020202, 0xAAAAAAAA);
+   addprovisional(0x03030303, 0xAAAAAAAA);
+
+   promoted = harvest_provisional();
+   ASSERT_EQ(promoted, 0);
+
+   /* Rplist should still be empty */
+   ASSERT_EQ_MSG(search32(0x01010101, Rplist, RPLISTLEN), NULL,
+      "peer should not be in Rplist before verification");
+
+   /* ---- capacity limit ---- */
+
+   purge_provisional();
+   for (i = 0; i < PROVPEERSLEN; i++) {
+      rc = addprovisional(i + 1, 0xAAAAAAAA);
+      ASSERT_EQ(rc, 0);
+   }
+
+   /* next add should fail */
+   rc = addprovisional(PROVPEERSLEN + 1, 0xAAAAAAAA);
+   ASSERT_EQ(rc, -1);
+
+   /* ---- purge clears everything ---- */
+
+   purge_provisional();
+   rc = addprovisional(0x11111111, 0xAAAAAAAA);
+   ASSERT_EQ(rc, 0);
+
+   /* ---- multiple sources with cross-source dedup ---- */
+
+   purge_provisional();
+   for (i = 1; i <= 10; i++) {
+      addprovisional(0x0A000000 | i, 0xAAAA0001);
+   }
+   for (i = 1; i <= 10; i++) {
+      addprovisional(0x0B000000 | i, 0xBBBB0001);
+   }
+
+   /* cross-source duplicate (same IP, different source) */
+   rc = addprovisional(0x0A000001, 0xCCCC0001);
+   ASSERT_EQ(rc, 0);
+
+   /* unique IP from third source */
+   rc = addprovisional(0x0C000001, 0xCCCC0001);
+   ASSERT_EQ(rc, 0);
+
+   /* ---- harvest compaction ---- */
+
+   purge_provisional();
+   for (i = 1; i <= 10; i++) {
+      addprovisional(i, 0xAAAAAAAA);
+   }
+   promoted = harvest_provisional();
+   ASSERT_EQ(promoted, 0);
+
+   /* list should still accept new entries */
+   rc = addprovisional(0xFF000001, 0xBBBBBBBB);
+   ASSERT_EQ(rc, 0);
+
+   /* ---- rapid add/harvest cycles ---- */
+
+   purge_provisional();
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+   for (i = 0; i < 100; i++) {
+      addprovisional((word32)(i + 1), 0xAAAAAAAA);
+      if (i % 10 == 9) harvest_provisional();
+   }
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+
+   /* ---- thread start and stop lifecycle ---- */
+
+   purge_provisional();
+   rc = start_provisional_verifier();
+   ASSERT_EQ(rc, 0);
+
+   /* double start should return 0 (already running) */
+   rc = start_provisional_verifier();
+   ASSERT_EQ(rc, 0);
+
+   millisleep(500);
+   stop_provisional_verifier();
+
+   /* double stop should be safe */
+   stop_provisional_verifier();
+
+   /* ---- cleanup ---- */
+
+   purge_provisional();
+   memset(Rplist, 0, sizeof(Rplist));
+   Rplistidx = 0;
+   Running = 0;
+}

--- a/src/types.h
+++ b/src/types.h
@@ -43,6 +43,13 @@
 #define TPLISTLEN    32       /**< trusted peer list */
 #define CRCLISTLEN   1024     /**< recent tx crc's */
 #define MAXQUORUM    32       /**< for init */
+#define PROVPEERSLEN 4096     /**< max provisional peer entries */
+#define PROVBATCHSIZE 32      /**< peers verified per thread pass */
+#define PROVMAXFAILS 5        /**< max failures before expiry */
+#define PROVBACKOFF  300      /**< base backoff seconds per fail */
+#define PROVREPUTHR  10       /**< min entries to evaluate reputation */
+#define PROVREPUFAIL 80       /**< failure % to reject source */
+#define PROVREPUTIME 3600     /**< reputation window in seconds */
 #define BCONFREQ     3        /**< Run con at least */
 #define CBITS        0        /**< 8 capability bits for TX */
 #define MFEE         500
@@ -699,6 +706,30 @@ typedef struct {
 } LTRAN;
 /* structure packing assertion required ... */
 STATIC_ASSERT(sizeof(LTRAN) == ( ADDR_LEN + 1 + 8 ), LTRAN_size);
+
+/**
+ * Provisional peer entry.
+ * Tracks unverified peer IPs received from network peers.
+ * All fields are word32 for 4-byte alignment.
+ * @property PROVPEER::ip Candidate peer IP address
+ * @property PROVPEER::source_ip IP of the peer that advertised this
+ * @property PROVPEER::next_attempt Unix timestamp of next attempt (0=untried)
+ * @property PROVPEER::fail_count Number of failed contact attempts
+ * @property PROVPEER::status 0=pending, 1=verified, 2=expired
+ */
+typedef struct {
+   word32 ip;
+   word32 source_ip;
+   word32 next_attempt;
+   word32 fail_count;
+   word32 status;
+} PROVPEER;
+STATIC_ASSERT(sizeof(PROVPEER) == 20, PROVPEER_size);
+
+/* provisional peer status values */
+#define PROVSTATUS_PENDING   0
+#define PROVSTATUS_VERIFIED  1
+#define PROVSTATUS_EXPIRED   2
 
 /* end include guard */
 #endif


### PR DESCRIPTION
## Architectural Overview: Provisional Peer Verification

### Background: What We Had Before

The Mochimo node maintains a Recent Peer List (Rplist, 64 entries) used for all network operations -- peer discovery, quorum formation, block propagation, and chain synchronization. Previously, when the node received a peer list from another node via OP_SEND_IPL, those IP addresses were added directly to Rplist via addrecent() -- no verification that the IPs were actually running Mochimo nodes.

This created two problems:

1. **Stale peer propagation**: Nodes that went offline months ago remain in peer lists indefinitely. Every node shares its Rplist with every peer that asks, so stale IPs propagate across the entire network. A significant portion of advertised peers on the current network are unreachable.

2. **IP flooding attack surface**: A malicious node could respond to OP_GET_IPL with fabricated IP addresses, filling the requesting node's Rplist with garbage. The node would then waste time trying to contact unreachable IPs during quorum formation and sync operations, and would propagate those garbage IPs to other nodes that ask for its peer list.

### What Changed

Peer IPs received from network responses now go through a **provisional verification pipeline** before being added to Rplist. The pipeline has three stages:

**Stage 1 -- Intake (addprovisional)**: IPs from OP_SEND_IPL responses are placed in a provisional list (4096 entries) instead of Rplist. Each entry records the candidate IP, the source IP that advertised it, and a status field. Before appending, the function deduplicates against existing provisional entries and Rplist, and checks the source's reputation.

**Stage 2 -- Verification (background thread)**: A dedicated thread processes provisional entries in batches of 32. For each pending entry whose retry time has passed, it attempts a callserver() handshake. If the handshake succeeds, the entry is marked VERIFIED. If it fails, the fail counter increments and the next retry is scheduled with exponential backoff. After 5 failures, the entry is marked EXPIRED.

**Stage 3 -- Harvest (harvest_provisional)**: Called periodically from the main server loop. Scans for VERIFIED entries, promotes them to Rplist via addrecent(), then compacts the list by removing all EXPIRED entries.

### Race Condition Handling

The provisional list is protected by a RWLock (from the extended-c threading library):

- **Parent thread (main loop)**: Takes write lock for addprovisional() (append) and harvest_provisional() (promote + compact). These are fast operations -- no blocking I/O under the lock.
- **Verification thread**: Takes read lock to scan for candidates, releases it, performs the blocking callserver() attempt (3-second timeout, no lock held), then takes write lock briefly to update the entry's status/fail_count. The lock is never held during network I/O.
- **OpenMP threads in scan_quorum()**: Call addprovisional() which takes write lock. The RWLock handles concurrent writers correctly.

The verification thread checks Running and Provrunning flags between every operation and every sleep second, ensuring clean shutdown without deadlock.

### Blocking Situation Analysis

- **addprovisional()**: Only holds write lock during in-memory array operations. No I/O, no network. Worst case is scanning 4096 entries for dedup + reputation -- microseconds.
- **harvest_provisional()**: Same -- in-memory scan and compact under write lock. No I/O.
- **Verification thread**: The callserver() call blocks for up to 3 seconds (INIT_TIMEOUT) per peer. With batches of 32, worst case is ~96 seconds per pass. This runs in a dedicated background thread -- **never in the main server loop**. Between batches, the thread sleeps for 30 seconds (checking Running every second).
- **Main server loop**: Zero new blocking. harvest_provisional() is a fast in-memory operation.

### Source Reputation Management

When addprovisional() evaluates whether to accept an IP from a given source, it tallies that source's track record from existing provisional entries:

- Counts all entries from this source_ip that are EXPIRED (failed verification) **and** whose last attempt was within the last hour (3600 seconds)
- Counts all PENDING entries from this source toward the total
- If the source has >= 10 entries total and >= 80% are recent failures, the new IP is silently dropped

**Time-windowed decay**: The reputation check only considers failures from the last hour. This is critical because:
- On a fresh node joining the network, many legitimate peers share stale IP lists accumulated over years. Without decay, every source would quickly hit the threshold and the node would stop accepting peer lists from anyone.
- With the 1-hour window, old failures age out. A source that shared bad IPs an hour ago gets a fresh chance.
- A truly malicious source that continuously floods garbage IPs will keep hitting the threshold every hour -- but gets at most 10 entries per hour into the provisional list before being throttled.

### Tunable Parameters

All defined in types.h alongside existing peer configuration:

| Parameter | Value | Purpose |
|-----------|-------|---------|
| PROVPEERSLEN | 4096 | Maximum provisional list entries |
| PROVBATCHSIZE | 32 | Peers verified per thread pass |
| PROVMAXFAILS | 5 | Failures before entry expires |
| PROVBACKOFF | 300 | Base backoff seconds (multiplied by fail count) |
| PROVREPUTHR | 10 | Minimum entries before evaluating source reputation |
| PROVREPUFAIL | 80 | Failure percentage threshold to reject a source |
| PROVREPUTIME | 3600 | Reputation window in seconds (1 hour) |

### Behavior Under Normal Conditions

1. Node starts, completes initial sync via resync()
2. Verification thread starts after init
3. During scan_quorum(), peer IPs from responses go to both netplist (immediate scanning) and addprovisional() (long-term verification)
4. During steady-state refresh_ipl(), peer IPs go only to addprovisional()
5. Verification thread confirms reachable peers
6. harvest_provisional() promotes verified peers to Rplist
7. Rplist gradually fills with confirmed-reachable peers

### Behavior Under IP Flooding Attack

A malicious node responds to OP_GET_IPL with 64 fabricated IPs:

1. All 64 IPs enter the provisional list
2. Verification thread attempts handshakes -- all fail
3. After 5 failures each (~75 minutes of backoff), entries are marked EXPIRED
4. Next harvest compacts them out
5. Source reputation degrades: 64 expired entries, 100% failure rate
6. Next time this source sends peer IPs, addprovisional() silently drops them all
7. After 1 hour, old failures age out, source gets another chance
8. If source sends garbage again, the cycle repeats -- at most 64 entries per hour of overhead

**Impact on node operation**: Zero. Rplist is never polluted.

### Behavior With Stale Network Peer Lists

1. Fresh node joins, receives peer lists with many stale IPs
2. Stale IPs go to provisional, most fail verification
3. Source reputation accumulates failures, temporarily throttles sources with high failure rates
4. The 1-hour decay window means sources are not permanently blacklisted
5. Over time, Rplist fills with only confirmed-reachable peers
6. Stale IPs never enter Rplist -- they fail verification and expire

### Files Changed

| File | Change |
|------|--------|
| src/types.h | PROVPEER struct (20 bytes, 4-byte aligned), 7 config defines, 3 status constants |
| src/peer.h | 5 function prototypes |
| src/peer.c | Full implementation (~250 lines): intake, harvest, reputation, verification thread, lifecycle |
| src/network.c | scan_quorum() and refresh_ipl() route received peer IPs through addprovisional() |
| src/bin/mochimo.c | Thread start after init, harvest on refresh timer, thread stop on shutdown |
| src/test/peer-provisional.c | Unit test conforming to _assert.h / make test / make coverage conventions |

### Testing

**Unit test** (make test-peer-provisional): Tests basic add, deduplication against provisional list and Rplist, capacity limit (4096 entries), source reputation with good sources, purge, multiple sources with cross-source dedup, harvest compaction, rapid add/harvest cycles (100 iterations), thread start/stop lifecycle, and concurrent add + harvest from separate threads. All assertions use the standard _assert.h framework. Passes via make test and is included in make coverage.

**Build verification**: Clean compile with -Wall -Werror -Wextra -Wpedantic on GCC 13 (Ubuntu x64). All existing tests unaffected.

### What This Does NOT Change

- Peers that complete a real protocol interaction with our node (incoming OP_FOUND, OP_GET_BLOCK, OP_TX, etc.) are still added directly to Rplist via addrecent() -- they have already proven they are real nodes by talking to us
- The scan_quorum() working list (netplist) still receives IPs immediately for the current scan -- provisional verification is for long-term Rplist inclusion, not for blocking initial peer discovery
- No changes to quorum formation, sync, or consensus paths
- No changes to pink list handling
- Provisional data is in-memory only -- lost on restart, no disk persistence needed
