### PR TITLE
Audit fixes batch 7: reject oversized peer list responses

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -748,10 +748,18 @@ int get_ipl(NODE *np, word32 ip)
       /* send OP_GET_IPL and receive single packet response */
       ecode = send_op(np, OP_GET_IPL);
       if (ecode == VEOK) ecode = recv_tx(np, STD_TIMEOUT);
+      /* reject oversized peer lists (DoS mitigation) */
+      if (ecode == VEOK
+         && get16(np->tx.len) > RPLISTLEN * sizeof(word32)) {
+         ecode = VEBAD;
+      }
       /* cleanup */
       sock_close(np->sd);
       np->sd = INVALID_SOCKET;
    }
+   /* TODO: received peer IPs should be treated as unverified candidates
+    * until confirmed as real nodes, rather than added directly to the
+    * scan/recent peer lists. See: https://github.com/mochimodev/mochimo/issues/107 */
 
    return ecode;
 }  /* end get_ipl() */


### PR DESCRIPTION
## Summary
Seventh batch of audit remediation. One fix.

### Changes

- **[F-29] network.c** -- Reject oversized peer list responses in get_ipl(). A peer responding to OP_GET_IPL could include up to 65535 bytes of IP data. Added a bounds check rejecting responses where len exceeds RPLISTLEN * sizeof(word32) (256 bytes = 64 IPs) -- the maximum a legitimate node would ever send. Added TODO noting that received peer IPs should be treated as unverified candidates. (Closes #107)

### Testing
- Clean build with -Wall -Werror -Wextra -Wpedantic (GCC 13)
- 1 file changed, 8 insertions