### PR TITLE
fix(tx): thread mfee parameter through to mdst_val()

### DIFF
--- a/src/tx.c
+++ b/src/tx.c
@@ -529,13 +529,14 @@ static int mdst_val__reference(const char *reference)
  * @private
  * Validate a Multi-Destination Transaction (incl. reference field).
  * @param txe Pointer to Transaction Entry to validate
+ * @param mfee Pointer to minimum fee (64-bit) to validate against
  * @return (int) value representing the validation result
  * @retval VEBAD2 on bad signature; check errno for details
  * @retval VEBAD on bad transaction; check errno for details
  * @retval VERROR on error; check errno for details
  * @retval VEOK on success
  */
-static int mdst_val(const TXENTRY *txe)
+static int mdst_val(const TXENTRY *txe, const void *mfee)
 {
    MDST *mdst = txe->mdst;
    word8 total[8] = {0};
@@ -570,7 +571,7 @@ static int mdst_val(const TXENTRY *txe)
          set_errno(EMCM_MATH64_OVERFLOW);
          return VEBAD;
       }
-      if (add64(mfees, Myfee, mfees)) {
+      if (add64(mfees, mfee, mfees)) {
          set_errno(EMCM_MFEES_OVERFLOW);
          return VEBAD;
       }
@@ -706,7 +707,7 @@ int tx_val(const TXENTRY *txe, const void *bnum, const void *mfee)
    switch (TXDAT_TYPE(txe->hdr)) {
       case TXDAT_MDST:
          /* ... validate destination array */
-         if (mdst_val(txe) != VEOK) return VEBAD;
+         if (mdst_val(txe, mfee) != VEOK) return VEBAD;
          break;
       default:
          set_errno(EMCM_XTXUNDEF);


### PR DESCRIPTION
## Summary

- Thread the existing `mfee` parameter from `tx_val()` into `mdst_val()` so that block validation uses the block-declared `bt.mfee` instead of the node's local `Myfee` global
- `Myfee` is intended for gating local block construction and mempool intake only, not for validating other miners' solved blocks

## Problem

`mdst_val()` used the global `Myfee` to validate per-destination fees in all code paths, including block validation (`bval.c` → `txe_val` → `tx_val` → `mdst_val`). Nodes with a higher `Myfee` would reject valid blocks from miners who accepted lower fees — a consensus split.

The design intent is that miners compete on fees: a miner who charges higher fees won't include low-fee transactions in their own block, but must still accept other miners' blocks that contain lower-fee transactions (as long as fees meet the protocol floor `MFEE = 500 nMCM`).

## Changes

Three lines in `src/tx.c`:
1. Add `const void *mfee` parameter to `mdst_val()` signature
2. Replace `Myfee` with `mfee` in the `add64()` fee tally (line 573)
3. Pass `mfee` through at the call site in `tx_val()` (line 709)

## Call paths after fix

| Path | `mfee` source | Behavior |
|------|--------------|----------|
| Block validation (`bval.c`) | `bt.mfee` | Respects other miner's fee decision |
| Mempool intake (`process_tx`) | `Myfee` | Enforces our local fee policy |
| Mempool revalidation (`txclean`) | `Myfee` | Enforces our local fee policy |

## Format compatibility verified

- `bt.mfee` (`word8[8]`) and `Myfee` (`word32[2]`) are both 8-byte little-endian 64-bit values
- `add64()` takes `const void *` — handles both interchangeably
- `bcon.c:492` writes via `put64(bt.mfee, Mfee)` — same serialization

## Test plan

- [ ] Verify `make test` passes (existing tests)
- [ ] Verify block validation accepts blocks with `bt.mfee < Myfee` (new behavior)
- [ ] Verify mempool intake still rejects transactions below local `Myfee`

Closes #93