### PR TITLE
fix(ledger): reject block on 64-bit balance overflow instead of zeroing

### DIFF
--- a/src/ledger.c
+++ b/src/ledger.c
@@ -640,10 +640,8 @@ int le_update(const char *ltfname)
                case 'A':
                   /* transaction CREDIT operation */
                   if (add64(le.balance, lt.amount, le.balance)) {
-                     /** @todo: reconsider math overflow as error? */
-                     /* set_errno(EMCM_MATH64_OVERFLOW); */
-                     /* goto FAIL_DROP; */
-                     memset(le.balance, 0, sizeof(le.balance));
+                     set_errno(EMCM_MATH64_OVERFLOW);
+                     goto DROP_CLEANUP;
                   }
                   break;
                case '-':


### PR DESCRIPTION
## Summary

- Reject blocks as malicious (`VEBAD2`) when a 64-bit balance credit overflows, instead of silently zeroing the account balance

## Problem

In `le_update()`, when `add64()` overflows during a credit (`'A'`) operation, the code zeroed the balance via `memset` and accepted the block. Total coin supply is ~2^56 nMCM — a single address cannot legitimately reach 2^64. An overflow here indicates a malformed or malicious block containing fabricated credit amounts that violate supply rules.

## Fix

Replace the `memset` zeroing with `set_errno(EMCM_MATH64_OVERFLOW)` and `goto DROP_CLEANUP`. The `DROP_CLEANUP` path (lines 735-745) properly:
- Sets return code to `VEBAD2` (malicious block)
- Closes `lefp` (ledger input), `ltfp` (ltran input), `fp` (output) if open
- Removes the partial `ledger.update` file

This is the same cleanup path already used by the debit mismatch case at line 654, from the same loop context.

## Test plan

- [ ] Verify `make test` passes
- [ ] No legitimate chain operation can trigger this (supply << 2^64)

Closes #95