### PR TITLE
fix(network): deterministic quorum assembly in scan_quorum()

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -980,22 +980,26 @@ int scan_quorum
                /* check peer's chain weight against highweight */
                result = cmp256(node.tx.weight, highweight);
                if (result >= 0) {
-                  /* higher or same chain detected */
-                  if (result > 0) {
-                     /* higher chain detected */
-                     pdebug("new highweight");
+                  /* new best chain: strictly higher weight, OR equal weight
+                   * with numerically higher block hash (deterministic
+                   * tiebreaker to ensure quorum members share a single chain,
+                   * regardless of peer scan order) */
+                  if (result > 0 ||
+                      memcmp(node.tx.cblockhash, highhash, HASHLEN) > 0) {
+                     pdebug("new high chain");
                      memcpy(highhash, node.tx.cblockhash, HASHLEN);
                      memcpy(highweight, node.tx.weight, 32);
                      put64(highbnum, node.tx.cblock);
                      qcount = 0;
                      if (quorum) {
                         memset(quorum, 0, qlen * sizeof(word32));
-                        pdebug("higher chain found, quourum reset...");
+                        pdebug("new high chain found, quorum reset...");
                      }
                   }
-                  /* check block hash and add to quorum */
-                  if (memcmp(node.tx.cblockhash, highhash, HASHLEN) >= 0) {
-                     /* add ip to quorum, or q consensus */
+                  /* add ip to quorum only if it shares the exact high chain
+                   * hash -- peers on different chains of equal weight must
+                   * not be combined into a single quorum */
+                  if (memcmp(node.tx.cblockhash, highhash, HASHLEN) == 0) {
                      if (quorum && qcount < qlen) {
                         quorum[qcount++] = peer;
                         pdebug("%s qualified", ntoa(&peer, NULL));


### PR DESCRIPTION
## Summary

- Make quorum assembly deterministic and scan-order invariant
- Ensure quorum members always share the exact same chain (weight + block hash)
- Use numerically-higher block hash as tiebreaker when chain weights are equal

## Problem

`scan_quorum()` at line 997 used `memcmp(peer_hash, highhash, HASHLEN) >= 0` to decide quorum membership. Since `highhash` was only updated on strictly higher weight, the first peer at the current high weight locked in `highhash`, and any later same-weight peer with an equal-or-higher hash was added to the quorum.

This allowed quorum members to be on different chains simultaneously at equal weight. Downstream `catchup()` parallelizes block downloads across the quorum, and interleaving blocks from different chains cannot coherently form a valid chain.

## Fix

Two changes in `src/network.c`:

1. Replace `highhash` when either strictly higher weight OR equal weight with numerically higher block hash. This provides a deterministic tiebreaker invariant to scan order.
2. Change quorum membership from `>= 0` to `== 0`. Only peers that exactly match the current high chain hash can join the quorum.

## Scope

This PR addresses only the narrow F-09 concern (mixed-chain quorums and scan-order dependence). A broader quorum/sync hardening effort — pre-download proof spot-checking, known-bad tfile caching, plurality-based chain selection, chain re-selection on validation failure, and fabricated-weight defense — will be proposed in a separate PR for careful review.

## Test plan

- [ ] Verify `make test` passes
- [ ] Multiple equal-weight peers with different hashes: only peers on the numerically-highest hash should join the quorum
- [ ] Scan order should not affect final quorum membership

Closes #100