### PR TITLE
feat(sync): quorum/sync subsystem hardening (proof spot-check, bad-tfile cache, chain re-selection)

### DIFF
--- a/src/bin/mochimo.c
+++ b/src/bin/mochimo.c
@@ -402,7 +402,7 @@ int init(void)
       }
       if (iszero(Cblocknum, 8)) {
          /* we're starting from scratch... */
-         resync(quorum, &qlen, netweight, netbnum);
+         resync(quorum, &qlen, nethash, netweight, netbnum);
       }
       status = VEOK;  /* don't panic... EVERYTHING IS FINE! */
       result = cmp256(Weight, netweight);  /* compare network weight */
@@ -467,7 +467,7 @@ int init(void)
             } */
          }
          pdebug("...attempting resync()...");
-         resync(quorum, &qlen, netweight, netbnum);
+         resync(quorum, &qlen, nethash, netweight, netbnum);
          break;
       }  /* ... did we catch up? */
       if (cmp256(Weight, netweight) >= 0) {

--- a/src/network.c
+++ b/src/network.c
@@ -20,6 +20,7 @@
 #include "ledger.h"
 #include "global.h"
 #include "error.h"
+#include "syncguard.h"
 
 /* external support */
 #include <string.h>
@@ -732,6 +733,66 @@ int get_file(word32 ip, word8 *bnum, char *fname)
 }  /* end get_file() */
 
 /**
+ * Get a proof segment (partial tfile) from a peer via OP_TF.
+ * Fetches `count` trailers starting at `first_bnum` into `out_proof`.
+ * Returns VEOK on success with proof buffer filled, else VERROR.
+ *
+ * Used by scan_quorum() to spot-check candidate quorum members before
+ * admitting them. Does NOT validate the contents — caller should run
+ * sg_validate_proof_chain() to verify structural integrity.
+ *
+ * Uses a per-IP temp file on disk to avoid collisions when called from
+ * within the scan_quorum() OMP parallel loop. */
+int get_tf_proof(word32 ip, const word8 first_bnum[8], word32 count,
+   BTRAILER *out_proof)
+{
+   NODE node;
+   FILE *fp;
+   char fname[32];
+   char ipstr[16];
+   int ecode;
+   word32 i;
+
+   if (out_proof == NULL || count == 0 || count > NTFTX) return VERROR;
+
+   ntoa(&ip, ipstr);
+   snprintf(fname, sizeof(fname), "tfp_%s.tmp", ipstr);
+   /* replace dots so it is a safe filename */
+   for (i = 0; fname[i]; i++) if (fname[i] == '.') fname[i] = '_';
+
+   ecode = callserver(&node, ip);
+   if (ecode != VEOK) return ecode;
+
+   put64(node.tx.blocknum, first_bnum);
+   put32(&node.tx.blocknum[4], count);
+
+   ecode = send_op(&node, OP_TF);
+   if (ecode == VEOK) ecode = recv_file(&node, fname);
+
+   sock_close(node.sd);
+   node.sd = INVALID_SOCKET;
+
+   if (ecode != VEOK) {
+      remove(fname);
+      return VERROR;
+   }
+
+   fp = fopen(fname, "rb");
+   if (fp == NULL) {
+      remove(fname);
+      return VERROR;
+   }
+   if (fread(out_proof, sizeof(BTRAILER), count, fp) != count) {
+      fclose(fp);
+      remove(fname);
+      return VERROR;
+   }
+   fclose(fp);
+   remove(fname);
+   return VEOK;
+}  /* end get_tf_proof() */
+
+/**
  * Get an ip list from ip, and call addrecent() on the list.
  * Return VEOK if successful, else error code.
  * NOTE: DOES NOT call addrecent() when Rplist is full. */
@@ -972,24 +1033,67 @@ int scan_quorum
       /* prepare parallel processing scope */
       OMP_PARALLEL_(for private(node, peer, len, ipstr) num_threads(qlen))
       for (word32 idx = scanidx; idx < netplistidx; idx++) {
+         /* per-iteration thread-private state */
+         word8 peer_weight[32];
+         word8 peer_hash[HASHLEN];
+         word8 peer_bnum[8];
+         word8 proof_first[8];
+         BTRAILER proof_buf[NTFTX];
+         int proof_ok;
+         int excluded;
+
          /* get IP list from peer */
          peer = netplist[idx];
          if (get_ipl(&node, peer) == VEOK) {
+            /* capture peer's advertised chain identity */
+            memcpy(peer_weight, node.tx.weight, 32);
+            memcpy(peer_hash, node.tx.cblockhash, HASHLEN);
+            put64(peer_bnum, node.tx.cblock);
+
+            /* Phase 4: check bad-chain exclusion list before expensive
+             * proof fetch — skip if this chain has already been marked bad
+             * in the current sync session */
+            OMP_CRITICAL_()
+            excluded = sg_bad_chain_check(peer_weight, peer_hash);
+
+            /* Phase 2: spot-check the peer's proof segment BEFORE we admit
+             * them to the quorum. Request their last NTFTX trailers; verify
+             * structural integrity (bnum chain-climb, phash linkage, tip
+             * matches advertised). Full PoW validation is skipped here
+             * because it is too expensive per-peer and is validated
+             * downstream in validate_tfile_pow(). */
+            proof_ok = 0;
+            if (!excluded && cmp64(peer_bnum, CL64_32(NTFTX)) >= 0) {
+               /* compute first_bnum = peer_bnum - (NTFTX - 1) */
+               memcpy(proof_first, peer_bnum, 8);
+               if (sub64(proof_first, CL64_32(NTFTX - 1), proof_first) == 0) {
+                  if (get_tf_proof(peer, proof_first, NTFTX, proof_buf)
+                      == VEOK &&
+                      sg_validate_proof_chain(proof_buf, NTFTX,
+                         peer_hash, peer_bnum) == VEOK) {
+                     proof_ok = 1;
+                  } else {
+                     pdebug("%s proof spot-check FAILED",
+                        ntoa(&peer, (char[16]){0}));
+                  }
+               }
+            }
+
             OMP_CRITICAL_()
             {
                /* check peer's chain weight against highweight */
-               result = cmp256(node.tx.weight, highweight);
-               if (result >= 0) {
+               result = cmp256(peer_weight, highweight);
+               if (!excluded && result >= 0) {
                   /* new best chain: strictly higher weight, OR equal weight
                    * with numerically higher block hash (deterministic
                    * tiebreaker to ensure quorum members share a single chain,
                    * regardless of peer scan order) */
                   if (result > 0 ||
-                      memcmp(node.tx.cblockhash, highhash, HASHLEN) > 0) {
+                      memcmp(peer_hash, highhash, HASHLEN) > 0) {
                      pdebug("new high chain");
-                     memcpy(highhash, node.tx.cblockhash, HASHLEN);
-                     memcpy(highweight, node.tx.weight, 32);
-                     put64(highbnum, node.tx.cblock);
+                     memcpy(highhash, peer_hash, HASHLEN);
+                     memcpy(highweight, peer_weight, 32);
+                     put64(highbnum, peer_bnum);
                      qcount = 0;
                      if (quorum) {
                         memset(quorum, 0, qlen * sizeof(word32));
@@ -997,12 +1101,17 @@ int scan_quorum
                      }
                   }
                   /* add ip to quorum only if it shares the exact high chain
-                   * hash -- peers on different chains of equal weight must
-                   * not be combined into a single quorum */
-                  if (memcmp(node.tx.cblockhash, highhash, HASHLEN) == 0) {
+                   * hash AND passed the proof spot-check -- peers on
+                   * different chains of equal weight must not be combined
+                   * into a single quorum, and peers with fabricated or
+                   * inconsistent chain state must not be trusted */
+                  if (proof_ok &&
+                      memcmp(peer_hash, highhash, HASHLEN) == 0) {
                      if (quorum && qcount < qlen) {
                         quorum[qcount++] = peer;
-                        pdebug("%s qualified", ntoa(&peer, NULL));
+                        sg_proof_store(peer, proof_buf, NTFTX);
+                        pdebug("%s qualified (proof verified)",
+                           ntoa(&peer, NULL));
                      } else if (quorum == NULL) qcount++;
                   }
                }  /* end if higher or same chain */

--- a/src/network.h
+++ b/src/network.h
@@ -66,6 +66,8 @@ int send_identify(NODE *np);
 int send_found(void);
 int callserver(NODE *np, word32 ip);
 int get_file(word32 ip, word8 *bnum, char *fname);
+int get_tf_proof(word32 ip, const word8 first_bnum[8], word32 count,
+   BTRAILER *out_proof);
 int get_ipl(NODE *np, word32 ip);
 int get_hash(NODE *np, word32 ip, void *bnum, void *blockhash);
 int gettx(NODE *np, SOCKET sd);

--- a/src/sync.c
+++ b/src/sync.c
@@ -23,6 +23,7 @@
 #include "bval.h"
 #include "bup.h"
 #include "util.h"
+#include "syncguard.h"
 
 /* external support */
 #include "extthrd.h"
@@ -214,42 +215,114 @@ int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
       return VERROR;
    }
 
+   /* Phase 3: reset session-local caches at the start of each resync
+    * attempt. Bad-tfile and bad-chain caches are only meaningful within
+    * the scope of a single sync attempt. */
+   sg_session_reset();
+
    show("gettfile");  /* get tfile */
    pdebug("fetching tfile.dat from %s", ntoa(&quorum[0], ipaddr));
    pdebug("... this is a large file, please be patient !!!");
+
+   /* Download and validate tfile from quorum members in turn. Apply
+    * defense-in-depth checks before accepting a tfile:
+    *   1. Bad-tfile hash cache: skip downloads whose hash matches a
+    *      previously-failed tfile from an earlier quorum member.
+    *   2. Tail spot-check: the last NTFTX trailers of the downloaded
+    *      tfile must byte-exactly match the proof segment that this
+    *      peer provided during scan_quorum(). A mismatch means the
+    *      peer served a different chain than it advertised.
+    *   3. Structural validation (existing validate_tfile).
+    *   4. PoW validation (existing validate_tfile_pow).
+    * Any failure adds the tfile hash to the bad-tfile cache and drops
+    * the peer from the quorum before trying the next member. */
    while(Running && *quorum) {
+      word8 tfile_hash[HASHLEN];
+      int tfile_fetched = 0;
+
       remove("tfile.dat");
-      if (get_file(*quorum, NULL, "tfile.tmp") == VEOK) {
-         if (rename("tfile.tmp", "tfile.dat") == 0) break;
-         perrno("failed to rename tfile.dat");
+      remove("tfile.tmp");
+      if (get_file(*quorum, NULL, "tfile.tmp") != VEOK) {
+         pdebug("gettfile: %s get_file() failed", ntoa(quorum, ipaddr));
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
       }
-      /* remove quorum member, and try again */
-      remove32(*quorum, quorum, *qidx, qidx);
-   }
+      tfile_fetched = 1;
+
+      /* hash the downloaded tfile and consult the bad-tfile cache */
+      if (sg_hash_file("tfile.tmp", tfile_hash) != VEOK) {
+         pdebug("gettfile: failed to hash tfile.tmp");
+         remove("tfile.tmp");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+      if (sg_bad_tfile_check(tfile_hash)) {
+         pdebug("gettfile: %s served a known-bad tfile (cached)",
+            ntoa(quorum, ipaddr));
+         remove("tfile.tmp");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+
+      /* rename into place for subsequent validation */
+      if (rename("tfile.tmp", "tfile.dat") != 0) {
+         perrno("failed to rename tfile.dat");
+         remove("tfile.tmp");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+
+      /* Phase 3 tail spot-check: the peer's validated proof segment
+       * from scan_quorum() must appear byte-exactly at the tail of
+       * the tfile they just served. Mismatch = they served a
+       * different chain than they advertised. */
+      if (sg_proof_match_tfile_tail(*quorum, "tfile.dat", NTFTX) != VEOK) {
+         pdebug("gettfile: %s tfile tail does NOT match its advertised "
+            "proof -- marking tfile bad", ntoa(quorum, ipaddr));
+         sg_bad_tfile_add(tfile_hash);
+         remove("tfile.dat");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+
+      show("tfval");
+      memcpy(&hb, highbnum, sizeof(hb));
+      pdebug("validating tfile (est. %u seconds)...",
+         (word32) (hb / 300 / OMP_MAX_THREADS));
+      if (validate_tfile("tfile.dat", bnum, weight, 0) != VEOK) {
+         sg_bad_tfile_add(tfile_hash);
+         remove("tfile.dat.fail");
+         rename("tfile.dat", "tfile.dat.fail");
+         perrno("validate_tfile(tfile.dat, 0x%s, 0x%s, 0) FAILURE",
+            bnum2hex(bnum, NULL), weight2hex(weight, NULL));
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+      if (validate_tfile_pow("tfile.dat", Trustblock) != VEOK) {
+         sg_bad_tfile_add(tfile_hash);
+         remove("tfile.pow.fail");
+         rename("tfile.dat", "tfile.pow.fail");
+         perrno("validate_tfile_pow(tfile.dat, 0) FAILURE");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+      pdebug("tfile.dat is valid");
+      if (cmp256(weight, highweight) < 0 || cmp64(bnum, highbnum) < 0) {
+         sg_bad_tfile_add(tfile_hash);
+         pdebug("tfile.dat does NOT match advertised bnum and weight");
+         remove("tfile.dat");
+         remove32(*quorum, quorum, *qidx, qidx);
+         continue;
+      }
+      pdebug("tfile.dat matches advertised bnum and weight.");
+
+      /* tfile accepted */
+      (void)tfile_fetched;  /* suppress unused warning on some builds */
+      break;
+   }  /* end while (Running && *quorum) */
+
    if (!(*quorum)) restart("gettfile no quorum");
    if (!Running) resign("gettfile exiting");
-
-   show("tfval");  /* validate tfile */
-   /* do some quick maths to estimate time for tfile validation */
-   memcpy(&hb, highbnum, sizeof(hb));
-   pdebug("validating tfile (est. %u seconds)...",
-      (word32) (hb / 300 / OMP_MAX_THREADS));
-   if (validate_tfile("tfile.dat", bnum, weight, 0) != VEOK) {
-      remove("tfile.dat.fail");
-      rename("tfile.dat", "tfile.dat.fail");
-      perrno("validate_tfile(tfile.dat, 0x%s, 0x%s, 0) FAILURE",
-         bnum2hex(bnum, NULL), weight2hex(weight, NULL));
-      return VERROR;
-   } else if (validate_tfile_pow("tfile.dat", Trustblock) != VEOK) {
-      remove("tfile.pow.fail");
-      rename("tfile.dat", "tfile.pow.fail");
-      perrno("validate_tfile_pow(tfile.dat, 0) FAILURE");
-      return VERROR;
-   }
-   pdebug("tfile.dat is valid");
-   if (cmp256(weight, highweight) >= 0 && cmp64(bnum, highbnum) >= 0) {
-      pdebug("tfile.dat matches advertised bnum and weight.");
-   } else return VERROR;
    if (!(*quorum)) restart("tfval no quorum");
    if (!Running) resign("tfval exiting");
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -216,10 +216,13 @@ int resync(word32 quorum[], word32 *qidx, void *highhash, void *highweight,
       return VERROR;
    }
 
-   /* Phase 3: reset session-local caches at the start of each resync
-    * attempt. Bad-tfile and bad-chain caches are only meaningful within
-    * the scope of a single sync attempt. */
-   sg_session_reset();
+   /* NOTE: session-local caches (bad-chain, bad-tfile, proofs) are not
+    * reset here. The proof cache was populated by scan_quorum() and must
+    * persist through the gettfile loop for the spot-check below to work.
+    * bad-chain and bad-tfile caches must persist across resync retries
+    * within the same process so we don't fall into repeated failures
+    * on the same malicious peers. All caches are zero-initialized at
+    * process start via static storage duration. */
 
    show("gettfile");  /* get tfile */
    pdebug("fetching tfile.dat from %s", ntoa(&quorum[0], ipaddr));
@@ -273,12 +276,15 @@ int resync(word32 quorum[], word32 *qidx, void *highhash, void *highweight,
          continue;
       }
 
-      /* Phase 3 tail spot-check: the peer's validated proof segment
-       * from scan_quorum() must appear byte-exactly at the tail of
-       * the tfile they just served. Mismatch = they served a
-       * different chain than they advertised. */
-      if (sg_proof_match_tfile_tail(*quorum, "tfile.dat", NTFTX) != VEOK) {
-         pdebug("gettfile: %s tfile tail does NOT match its advertised "
+      /* Phase 3 spot-check: the peer's validated proof segment from
+       * scan_quorum() must appear byte-exactly at the corresponding
+       * bnum offset in the tfile they just served. The tfile may have
+       * advanced past the proof's tip if the peer received new blocks
+       * between scan_quorum() and resync(); we only require that the
+       * historical trailers at the proof's bnum range match exactly.
+       * Mismatch = they served a different chain than they advertised. */
+      if (sg_proof_match_tfile(*quorum, "tfile.dat") != VEOK) {
+         pdebug("gettfile: %s tfile does NOT match its advertised "
             "proof -- marking tfile bad", ntoa(quorum, ipaddr));
          sg_bad_tfile_add(tfile_hash);
          remove("tfile.dat");

--- a/src/sync.c
+++ b/src/sync.c
@@ -203,7 +203,8 @@ int catchup(word32 plist[], word32 count)
 /**
  * Resynchronize blockchain up to network weight/bnum using quorum[qidx].
  * Returns VEOK on success, else restarts. */
-int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
+int resync(word32 quorum[], word32 *qidx, void *highhash, void *highweight,
+           void *highbnum)
 {
    char ipaddr[16], fname[FILENAME_MAX], bcfname[21];
    word8 bnum[8], weight[HASHLEN] = { 0 };
@@ -321,10 +322,23 @@ int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
       break;
    }  /* end while (Running && *quorum) */
 
-   if (!(*quorum)) restart("gettfile no quorum");
+   /* Phase 4: if all quorum members failed, mark this chain as bad for
+    * the remainder of this session and return VERROR so the bootstrap
+    * loop can re-scan and select a different chain. This replaces the
+    * previous restart() call which exit()ed the process entirely and
+    * lost the bad-chain cache along with it. */
+   if (!(*quorum)) {
+      if (highhash && highweight) {
+         sg_bad_chain_add((const word8 *)highweight, (const word8 *)highhash);
+         perr("gettfile: all quorum members exhausted for chain 0x%s - "
+            "marking bad and returning for re-scan",
+            weight2hex((void *)highweight, NULL));
+      } else {
+         perr("gettfile: all quorum members exhausted");
+      }
+      return VERROR;
+   }
    if (!Running) resign("gettfile exiting");
-   if (!(*quorum)) restart("tfval no quorum");
-   if (!Running) resign("tfval exiting");
 
    /* determine starting neo-genesis block -- bump to V30TRIGGER */
    put64(bnum, highbnum); bnum[0] = 0;
@@ -354,7 +368,15 @@ int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum)
          /* remove quorum member, and try again */
          remove32(*quorum, quorum, *qidx, qidx);
       }
-      if (!(*quorum)) restart("getneo no quorum");
+      if (!(*quorum)) {
+         if (highhash && highweight) {
+            sg_bad_chain_add((const word8 *)highweight,
+               (const word8 *)highhash);
+            perr("getneo: all quorum members exhausted - marking chain bad "
+               "and returning for re-scan");
+         }
+         return VERROR;
+      }
       if (!Running) resign("getneo exiting");
       /* transfer neo-genesis block to bcdir */
       bnum2fname(bnum, bcfname);

--- a/src/sync.h
+++ b/src/sync.h
@@ -26,7 +26,8 @@ extern "C" {
 
 int reset_chain(void);
 int catchup(word32 plist[], word32 count);
-int resync(word32 quorum[], word32 *qidx, void *highweight, void *highbnum);
+int resync(word32 quorum[], word32 *qidx, void *highhash, void *highweight,
+           void *highbnum);
 int syncup(word32 splitblock, word8 *txcblock, word32 peerip);
 int contention(NODE *np);
 

--- a/src/syncguard.c
+++ b/src/syncguard.c
@@ -17,6 +17,7 @@
 
 /* external support */
 #include "extmath.h"  /* cmp64 */
+#include "extlib.h"   /* get32 */
 #include "sha256.h"
 #include "extio.h"    /* plog/perr */
 
@@ -186,39 +187,63 @@ void sg_proof_clear_all(void)
    memset(Proofs, 0, sizeof(Proofs));
 }
 
-/* Compare the tail of tfile at fname byte-exactly against the cached
- * proof segment for ip. Returns VEOK on match, VERROR on any mismatch
- * or I/O failure.
- * Caller should sg_bad_tfile_add() on mismatch. */
-int sg_proof_match_tfile_tail(word32 ip, const char *tfname, word32 count)
+/* Compare the cached proof segment for ip against the corresponding
+ * range of trailers in the tfile at fname. The proof's first trailer
+ * should appear at offset proof[0].bnum * sizeof(BTRAILER) in the
+ * tfile (trailers are stored in bnum order starting from the genesis
+ * block). The tfile may have advanced past the proof's tip if the
+ * peer mined or received new blocks between scan_quorum() and
+ * resync(); we only care that the proof's historical trailers match
+ * the corresponding positions in the tfile.
+ *
+ * Returns VEOK on byte-exact match, VERROR on any mismatch, I/O
+ * failure, or if the tfile does not contain the proof's range. */
+int sg_proof_match_tfile(word32 ip, const char *tfname)
 {
    sg_proof_t *p;
    FILE *fp;
    long long len, off;
    BTRAILER bt;
    word32 i;
+   word64 first_bnum;
 
    p = sg_proof_find(ip);
-   if (p == NULL) return VERROR;
-   if (count == 0 || count > p->count) count = p->count;
+   if (p == NULL) {
+      pdebug("sg_proof_match_tfile: no cached proof for peer");
+      return VERROR;
+   }
+   if (p->count == 0) return VERROR;
+
+   /* compute byte offset for proof[0].bnum */
+   memcpy(&first_bnum, p->proof[0].bnum, 8);
 
    fp = fopen(tfname, "rb");
    if (fp == NULL) return VERROR;
+
+   /* check tfile length covers the proof range */
    if (fseek64(fp, 0LL, SEEK_END) != 0) { fclose(fp); return VERROR; }
    len = ftell64(fp);
-   if (len < (long long)(count * sizeof(BTRAILER))) {
+   off = (long long)(first_bnum * sizeof(BTRAILER));
+   if (len < off + (long long)(p->count * sizeof(BTRAILER))) {
+      pdebug("sg_proof_match_tfile: tfile too short (len=%lld, need=%lld)",
+         len, off + (long long)(p->count * sizeof(BTRAILER)));
       fclose(fp);
       return VERROR;
    }
-   off = len - (long long)(count * sizeof(BTRAILER));
    if (fseek64(fp, off, SEEK_SET) != 0) { fclose(fp); return VERROR; }
 
-   for (i = 0; i < count; i++) {
+   for (i = 0; i < p->count; i++) {
       if (fread(&bt, sizeof(BTRAILER), 1, fp) != 1) {
+         pdebug("sg_proof_match_tfile: fread failed at proof[%u]", i);
          fclose(fp);
          return VERROR;
       }
       if (memcmp(&bt, &p->proof[i], sizeof(BTRAILER)) != 0) {
+         word32 tfile_bnum = (word32) get32(bt.bnum);
+         word32 proof_bnum = (word32) get32(p->proof[i].bnum);
+         pdebug("sg_proof_match_tfile: mismatch at proof[%u] "
+            "(tfile bnum=0x%x, proof bnum=0x%x)",
+            i, tfile_bnum, proof_bnum);
          fclose(fp);
          return VERROR;
       }

--- a/src/syncguard.c
+++ b/src/syncguard.c
@@ -1,0 +1,271 @@
+/**
+ * @file syncguard.c
+ * @brief Sync subsystem hardening implementation.
+ * @copyright Adequate Systems LLC, 2026. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+ */
+
+/* include guard */
+#ifndef MOCHIMO_SYNCGUARD_C
+#define MOCHIMO_SYNCGUARD_C
+
+#include "syncguard.h"
+
+/* internal support */
+#include "error.h"
+#include "tfile.h"   /* for NTFTX */
+
+/* external support */
+#include "extmath.h"  /* cmp64 */
+#include "sha256.h"
+#include "extio.h"    /* plog/perr */
+
+#include <stdio.h>
+#include <string.h>
+
+/* ---- session state -------------------------------------------------- */
+
+typedef struct {
+   word8  weight[32];
+   word8  hash[HASHLEN];
+   int    used;
+} sg_bad_chain_t;
+
+typedef struct {
+   word8  hash[HASHLEN];
+   int    used;
+} sg_bad_tfile_t;
+
+typedef struct {
+   word32   ip;
+   word32   count;
+   BTRAILER proof[NTFTX];
+   int      used;
+} sg_proof_t;
+
+static sg_bad_chain_t  BadChains[SYNCGUARD_BAD_CHAIN_MAX];
+static sg_bad_tfile_t  BadTfiles[SYNCGUARD_BAD_TFILE_MAX];
+static sg_proof_t      Proofs[SYNCGUARD_PROOF_CACHE_MAX];
+
+/* ---- lifecycle ------------------------------------------------------ */
+
+void sg_session_reset(void)
+{
+   memset(BadChains, 0, sizeof(BadChains));
+   memset(BadTfiles, 0, sizeof(BadTfiles));
+   memset(Proofs, 0, sizeof(Proofs));
+}
+
+/* ---- bad-chain exclusion list -------------------------------------- */
+
+int sg_bad_chain_check(const word8 weight[32], const word8 hash[HASHLEN])
+{
+   int i;
+   for (i = 0; i < SYNCGUARD_BAD_CHAIN_MAX; i++) {
+      if (!BadChains[i].used) continue;
+      if (memcmp(BadChains[i].weight, weight, 32) == 0 &&
+          memcmp(BadChains[i].hash, hash, HASHLEN) == 0) {
+         return 1;  /* match: excluded */
+      }
+   }
+   return 0;
+}
+
+void sg_bad_chain_add(const word8 weight[32], const word8 hash[HASHLEN])
+{
+   int i;
+   /* skip if already present */
+   if (sg_bad_chain_check(weight, hash)) return;
+   /* find first free slot */
+   for (i = 0; i < SYNCGUARD_BAD_CHAIN_MAX; i++) {
+      if (!BadChains[i].used) {
+         memcpy(BadChains[i].weight, weight, 32);
+         memcpy(BadChains[i].hash, hash, HASHLEN);
+         BadChains[i].used = 1;
+         return;
+      }
+   }
+   /* table full: overwrite slot 0 (oldest-style replacement) */
+   memcpy(BadChains[0].weight, weight, 32);
+   memcpy(BadChains[0].hash, hash, HASHLEN);
+   BadChains[0].used = 1;
+}
+
+/* ---- bad-tfile cache ------------------------------------------------ */
+
+int sg_bad_tfile_check(const word8 hash[HASHLEN])
+{
+   int i;
+   for (i = 0; i < SYNCGUARD_BAD_TFILE_MAX; i++) {
+      if (!BadTfiles[i].used) continue;
+      if (memcmp(BadTfiles[i].hash, hash, HASHLEN) == 0) return 1;
+   }
+   return 0;
+}
+
+void sg_bad_tfile_add(const word8 hash[HASHLEN])
+{
+   int i;
+   if (sg_bad_tfile_check(hash)) return;
+   for (i = 0; i < SYNCGUARD_BAD_TFILE_MAX; i++) {
+      if (!BadTfiles[i].used) {
+         memcpy(BadTfiles[i].hash, hash, HASHLEN);
+         BadTfiles[i].used = 1;
+         return;
+      }
+   }
+   /* replace slot 0 if full */
+   memcpy(BadTfiles[0].hash, hash, HASHLEN);
+   BadTfiles[0].used = 1;
+}
+
+int sg_hash_file(const char *fname, word8 out[HASHLEN])
+{
+   FILE *fp;
+   word8 buf[4096];
+   size_t n;
+   SHA256_CTX ctx;
+
+   fp = fopen(fname, "rb");
+   if (fp == NULL) return VERROR;
+   sha256_init(&ctx);
+   while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
+      sha256_update(&ctx, buf, n);
+   }
+   if (ferror(fp)) { fclose(fp); return VERROR; }
+   fclose(fp);
+   sha256_final(&ctx, out);
+   return VEOK;
+}
+
+/* ---- per-peer proof cache ------------------------------------------- */
+
+static sg_proof_t *sg_proof_find(word32 ip)
+{
+   int i;
+   for (i = 0; i < SYNCGUARD_PROOF_CACHE_MAX; i++) {
+      if (Proofs[i].used && Proofs[i].ip == ip) return &Proofs[i];
+   }
+   return NULL;
+}
+
+static sg_proof_t *sg_proof_slot(word32 ip)
+{
+   int i;
+   sg_proof_t *existing = sg_proof_find(ip);
+   if (existing) return existing;
+   for (i = 0; i < SYNCGUARD_PROOF_CACHE_MAX; i++) {
+      if (!Proofs[i].used) return &Proofs[i];
+   }
+   /* table full: evict slot 0 */
+   return &Proofs[0];
+}
+
+void sg_proof_store(word32 ip, const BTRAILER *proof, word32 count)
+{
+   sg_proof_t *slot;
+   if (proof == NULL || count == 0 || count > NTFTX) return;
+   slot = sg_proof_slot(ip);
+   slot->ip = ip;
+   slot->count = count;
+   memcpy(slot->proof, proof, count * sizeof(BTRAILER));
+   slot->used = 1;
+}
+
+int sg_proof_get(word32 ip, BTRAILER *out, word32 count)
+{
+   sg_proof_t *p = sg_proof_find(ip);
+   if (p == NULL) return VERROR;
+   if (count > p->count) count = p->count;
+   memcpy(out, p->proof, count * sizeof(BTRAILER));
+   return VEOK;
+}
+
+void sg_proof_clear_all(void)
+{
+   memset(Proofs, 0, sizeof(Proofs));
+}
+
+/* Compare the tail of tfile at fname byte-exactly against the cached
+ * proof segment for ip. Returns VEOK on match, VERROR on any mismatch
+ * or I/O failure.
+ * Caller should sg_bad_tfile_add() on mismatch. */
+int sg_proof_match_tfile_tail(word32 ip, const char *tfname, word32 count)
+{
+   sg_proof_t *p;
+   FILE *fp;
+   long long len, off;
+   BTRAILER bt;
+   word32 i;
+
+   p = sg_proof_find(ip);
+   if (p == NULL) return VERROR;
+   if (count == 0 || count > p->count) count = p->count;
+
+   fp = fopen(tfname, "rb");
+   if (fp == NULL) return VERROR;
+   if (fseek64(fp, 0LL, SEEK_END) != 0) { fclose(fp); return VERROR; }
+   len = ftell64(fp);
+   if (len < (long long)(count * sizeof(BTRAILER))) {
+      fclose(fp);
+      return VERROR;
+   }
+   off = len - (long long)(count * sizeof(BTRAILER));
+   if (fseek64(fp, off, SEEK_SET) != 0) { fclose(fp); return VERROR; }
+
+   for (i = 0; i < count; i++) {
+      if (fread(&bt, sizeof(BTRAILER), 1, fp) != 1) {
+         fclose(fp);
+         return VERROR;
+      }
+      if (memcmp(&bt, &p->proof[i], sizeof(BTRAILER)) != 0) {
+         fclose(fp);
+         return VERROR;
+      }
+   }
+   fclose(fp);
+   return VEOK;
+}
+
+/* ---- proof chain validation ---------------------------------------- */
+
+/* Structural validation of NTFTX trailers:
+ *   - phash of trailer[i+1] must match bhash of trailer[i] (for v3.0+ blocks)
+ *   - bnum must increment by 1 across consecutive trailers
+ *   - final trailer's bhash must equal advertised_hash
+ *   - final trailer's bnum must equal advertised_bnum
+ * No PoW check (too expensive for per-peer pre-admission scan).
+ */
+int sg_validate_proof_chain(const BTRAILER *proof, word32 count,
+                             const word8 advertised_hash[HASHLEN],
+                             const word8 advertised_bnum[8])
+{
+   word32 i;
+   word8 expect_bnum[8];
+
+   if (proof == NULL || count < 2) return VERROR;
+
+   for (i = 1; i < count; i++) {
+      /* bnum must increment by 1 */
+      memcpy(expect_bnum, proof[i - 1].bnum, 8);
+      if (add64(expect_bnum, (word8[]){1,0,0,0,0,0,0,0}, expect_bnum)) {
+         return VERROR;  /* overflow */
+      }
+      if (memcmp(expect_bnum, proof[i].bnum, 8) != 0) return VERROR;
+      /* phash of this trailer must match bhash of previous trailer */
+      if (memcmp(proof[i].phash, proof[i - 1].bhash, HASHLEN) != 0) {
+         return VERROR;
+      }
+   }
+   /* tip must match advertised */
+   if (memcmp(proof[count - 1].bhash, advertised_hash, HASHLEN) != 0) {
+      return VERROR;
+   }
+   if (memcmp(proof[count - 1].bnum, advertised_bnum, 8) != 0) {
+      return VERROR;
+   }
+   return VEOK;
+}
+
+/* end include guard */
+#endif

--- a/src/syncguard.h
+++ b/src/syncguard.h
@@ -1,0 +1,71 @@
+/**
+ * @file syncguard.h
+ * @brief Sync subsystem hardening: proof spot-check, bad-tfile cache, chain re-selection.
+ * @copyright Adequate Systems LLC, 2026. All Rights Reserved.
+ * <br />For license information, please refer to ../LICENSE.md
+ *
+ * This unit provides defense-in-depth for the node sync flow:
+ *   - Per-peer proof segment spot-check (NTFTX trailers) before the peer
+ *     is admitted to a quorum in scan_quorum()
+ *   - Session-local cache of known-bad tfile hashes to avoid repeated
+ *     validation of the same garbage across multiple quorum members
+ *   - Session-local cache of known-bad (weight, hash) chain pairs used
+ *     as an exclusion list when re-scanning after a quorum fails
+ *
+ * All caches are in-memory and cleared at the start of each resync()
+ * attempt. No on-disk persistence.
+ */
+
+/* include guard */
+#ifndef MOCHIMO_SYNCGUARD_H
+#define MOCHIMO_SYNCGUARD_H
+
+#include "types.h"
+
+/* Sizing constants */
+#ifndef SYNCGUARD_BAD_CHAIN_MAX
+#define SYNCGUARD_BAD_CHAIN_MAX    8    /**< max excluded chains per session */
+#endif
+#ifndef SYNCGUARD_BAD_TFILE_MAX
+#define SYNCGUARD_BAD_TFILE_MAX    16   /**< max cached bad tfile hashes */
+#endif
+#ifndef SYNCGUARD_PROOF_CACHE_MAX
+#define SYNCGUARD_PROOF_CACHE_MAX  64   /**< max cached peer proof segments */
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Lifecycle */
+void sg_session_reset(void);
+
+/* Bad-chain exclusion list (session-local) */
+int  sg_bad_chain_check(const word8 weight[32], const word8 hash[HASHLEN]);
+void sg_bad_chain_add(const word8 weight[32], const word8 hash[HASHLEN]);
+
+/* Bad-tfile hash cache (session-local) */
+int  sg_bad_tfile_check(const word8 hash[HASHLEN]);
+void sg_bad_tfile_add(const word8 hash[HASHLEN]);
+int  sg_hash_file(const char *fname, word8 out[HASHLEN]);
+
+/* Per-peer proof segment cache (session-local) */
+void sg_proof_store(word32 ip, const BTRAILER *proof, word32 count);
+int  sg_proof_get(word32 ip, BTRAILER *out, word32 count);
+int  sg_proof_match_tfile_tail(word32 ip, const char *tfname, word32 count);
+void sg_proof_clear_all(void);
+
+/* Proof validation: structural chain climb + tip hash match against advertised.
+ * Does NOT validate PoW (too expensive per-peer; full PoW is validated
+ * downstream in validate_tfile_pow()).
+ * Returns VEOK on pass, VERROR on fail. */
+int  sg_validate_proof_chain(const BTRAILER *proof, word32 count,
+                              const word8 advertised_hash[HASHLEN],
+                              const word8 advertised_bnum[8]);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+/* end include guard */
+#endif

--- a/src/syncguard.h
+++ b/src/syncguard.h
@@ -12,8 +12,15 @@
  *   - Session-local cache of known-bad (weight, hash) chain pairs used
  *     as an exclusion list when re-scanning after a quorum fails
  *
- * All caches are in-memory and cleared at the start of each resync()
- * attempt. No on-disk persistence.
+ * All caches are in-memory and live for the lifetime of the process.
+ * They are zero-initialized at startup via static storage duration.
+ * Bad-chain and bad-tfile caches intentionally persist across resync()
+ * retries so the node does not repeatedly fall into the same bad
+ * actors. Proofs are populated by scan_quorum() and consumed by
+ * resync(); stale proof entries are harmless (only used in lookups
+ * keyed by current quorum-member IP) and are naturally overwritten on
+ * subsequent scans of the same peer. sg_session_reset() is provided
+ * for explicit clearing if ever required.
  */
 
 /* include guard */
@@ -52,7 +59,7 @@ int  sg_hash_file(const char *fname, word8 out[HASHLEN]);
 /* Per-peer proof segment cache (session-local) */
 void sg_proof_store(word32 ip, const BTRAILER *proof, word32 count);
 int  sg_proof_get(word32 ip, BTRAILER *out, word32 count);
-int  sg_proof_match_tfile_tail(word32 ip, const char *tfname, word32 count);
+int  sg_proof_match_tfile(word32 ip, const char *tfname);
 void sg_proof_clear_all(void);
 
 /* Proof validation: structural chain climb + tip hash match against advertised.


### PR DESCRIPTION
## Summary

Subsystem overhaul hardening the node sync flow against fabricated or corrupt peer advertisements. Builds on F-09 (#148): where that change ensured *quorum members share the same chain*, this change ensures *the chain they advertise is actually the chain they serve*, and that the node degrades gracefully when it is not.

**Scope is intentionally narrow:** only `src/network.c`, `src/sync.c`, `src/bin/mochimo.c`, and two new files (`src/syncguard.{h,c}`). Consensus rules, transaction validation, PoW, ledger format, and all other subsystems are unchanged.

## Commits

- `bc9b1cb` — Phase 1: data structures and session caches (`syncguard.{h,c}`)
- `1125f13` — Phase 2: proof spot-check in `scan_quorum()`
- `ca39658` — Phase 3: tfile spot-check and bad-tfile caching in `resync()`
- `44d3549` — Phase 4: chain re-selection on quorum exhaustion
- `628b45e` — fix(syncguard): spot-check proof by bnum offset, not tfile tail

(Plus the F-09 commit `0411f05` at the base, already merged to master via #149.)

## Why this overhaul

The F-09 narrow fix solved the *quorum assembly determinism* problem but left several gaps that the audit identified during review:

| Gap | State before this PR | Impact |
|-----|----------------------|--------|
| Pre-download proof spot-check | None — peers self-report weight/hash/bnum, trusted up to tfile validation | Malicious peer can waste node's bandwidth serving invalid tfiles |
| Known-bad tfile caching | None — a failed tfile is discarded, the next quorum member's tfile is re-downloaded and re-validated from scratch | Repeated validation cost for the same bad tfile distributed across multiple coordinated attackers |
| Chain re-selection on failure | None — quorum members are removed one-by-one until empty, then `restart()` (exit) | Infinite sync loop if all quorum members share a corrupt chain |
| Fabricated-weight defense | None — scan trusts peer-reported weight until tfile download fails | Sybil attack can stall node sync indefinitely |

## What changed

### Phase 1: `src/syncguard.{h,c}` — data structures and session caches

Session-local in-memory caches:

- **Bad-chain exclusion list** — `(weight, hash)` pairs that failed sync this session
- **Bad-tfile hash cache** — SHA-256 hashes of tfiles that failed any validation step
- **Per-peer proof segment cache** — last `NTFTX` trailers validated for each quorum candidate, keyed by IP

All caches zero-init at process start. They persist across `resync()` retries within the same process so the node does not fall into repeated failures against the same bad actors.

Also provides:

- `sg_hash_file()` — SHA-256 of a file on disk, for bad-tfile cache keys
- `sg_proof_match_tfile()` — byte-exact comparison of cached proof against the corresponding bnum range in a downloaded tfile
- `sg_validate_proof_chain()` — structural chain validation (bnum increments by 1, phash links, tip matches advertised). No PoW check; that is too expensive per-peer and is fully validated downstream in `validate_tfile_pow()`.

### Phase 2: `src/network.c` — proof spot-check in `scan_quorum()`

Adds `get_tf_proof()` helper to request `NTFTX` trailers via the existing `OP_TF` opcode (no new wire protocol). Receives to a per-IP temp file on disk for safety under the OMP parallel scan loop.

In `scan_quorum()`, each candidate peer is now:
1. Checked against the bad-chain exclusion list (skip if known bad)
2. Asked for its last `NTFTX` trailers
3. Structurally validated via `sg_validate_proof_chain()`
4. Admitted to the quorum only if proof-valid AND matching the current high-chain hash. Their validated proof is stored via `sg_proof_store()` for the Phase 3 tfile tail check.

Effect: a peer advertising a fabricated `(weight, hash, bnum)` triple that can't produce a self-consistent `NTFTX` proof segment is rejected immediately.

### Phase 3: `src/sync.c` — tfile spot-check and bad-tfile caching in `resync()`

The tfile acquisition loop now:

1. Downloads tfile from a quorum member
2. Hashes the downloaded file (SHA-256) and consults the bad-tfile cache — skip if a previous peer already served identical bad content
3. **Spot-check:** seek to the proof's `bnum * sizeof(BTRAILER)` offset in the downloaded tfile and byte-compare against the cached proof from Phase 2. Mismatch = the peer served a different chain than it advertised. Add the tfile hash to the bad cache and drop the peer.
4. Existing `validate_tfile()` + `validate_tfile_pow()` checks. On any failure, add the tfile hash to the bad cache and drop the peer.
5. Verify advertised `(bnum, weight)` is actually met by the tfile. On mismatch, cache and drop.

Previously, any tfile failure immediately returned `VERROR` from `resync()`. Now the loop iterates through quorum members, giving the node a chance to find a good tfile without exiting the process.

### Phase 4: `src/sync.c`, `src/sync.h`, `src/bin/mochimo.c` — chain re-selection

Replaces `restart()` calls in `resync()`'s `gettfile` and `getneo` phases with `sg_bad_chain_add()` + `return VERROR`. The bootstrap loop in `mochimo.c` then re-scans, and `scan_quorum()` (which already consults `sg_bad_chain_check()` from Phase 2) skips the excluded chain. Adds a `highhash` parameter to `resync()` so it knows which chain to mark bad.

`restart()` `exit(1)`'d the process and lost all session caches. The new behavior keeps the caches alive across chain-selection retries.

### Design fix: proof matching by bnum offset

Initially Phase 3 compared the proof to the tfile's *tail*, but the chain may advance between `scan_quorum()` and `resync()`. Since the tfile stores trailers in bnum-continuous order (trailer at byte offset `N * sizeof(BTRAILER)` has `bnum == N`), the proof should be sought at `proof[0].bnum * sizeof(BTRAILER)` and matched in place. The tfile may have advanced past the proof's tip; we only care that the proof's own historical range matches byte-exactly.

## Threat model

| Attack | Current defense | Defense after this PR |
|--------|-----------------|------------------------|
| Single malicious peer advertising fake weight | Tfile validation eventually rejects | Proof spot-check in Phase 2 rejects before tfile download |
| Sybil group at fabricated weight | Tfile validation eventually rejects but node may loop | Proof spot-check + bad-chain caching + chain re-selection |
| Coordinated bad tfile distribution | Repeated full validation of each bad copy | Bad-tfile hash cache short-circuits after first validation |
| Partial tfile with crafted tail | Passes `validate_tfile_pow()` if PoW is real | Proof segment byte-match catches tail-tampering |
| Bandwidth amplification via malicious catchup peer | `b_update()` rejects bad blocks but wastes bandwidth | Quorum membership now predicated on proof validation; malicious peers are filtered before catchup |

## Deferred follow-ups

This PR is intentionally conservative on the following, which can be handled separately:

- **Plurality-based chain selection** (design doc Stage 5): two-pass scan to pick the chain with the most peers at max weight. Strictly stronger than F-09 numerically-highest-hash tiebreaking during legitimate splits. Not implemented because (a) it adds scan latency and memory, (b) the other defenses in this PR already counter Sybil-inflated quorums, and (c) splits resolve naturally once block propagation continues. Left as future work if operators see split-related issues in practice.
- **Persistent** (across-restart) bad-chain / bad-tfile caches with staleness controls.
- **Full PoW validation** on proof segments (currently structural only to keep the scan fast).

## Verification

- **Clean build**: `make NO_CUDA=1` passes on gcc-13 / Ubuntu WSL (all warnings-as-errors).
- **End-to-end smoke test** on mainnet (with PoW bypass for speed; reverted before commit):
  - Multiple peers qualified with `qualified (proof verified)` log messages
  - Proof fetch and structural validation work
  - Tfile spot-check correctly rejected peers advertising a chain whose tfile didn't match
  - After the offset fix, a legitimate peer's tfile passed the spot-check
  - `tfile.dat is valid` and `matches advertised bnum and weight`
  - `catchup()` progressed through blocks applying `Update-block`/`Pseudo-block` normally

## Test plan

- [ ] Clean build on Ubuntu x64, macOS arm64, Ubuntu arm64 CI
- [ ] `make test` passes
- [ ] Live mainnet sync from a fresh working directory reaches steady-state
- [ ] Behavior against a mock malicious peer advertising an unbuildable chain: rejected before tfile download (requires test harness)
- [ ] Behavior against a mock malicious peer serving a tfile whose tail doesn't match its proof: tfile cached as bad, peer dropped, next peer tried