### PR TITLE
fix(tfile): read_tfile() returns 0 on error instead of 1 (F-23, #99)

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -602,7 +602,10 @@ bad:
    /* get proof from tfile.dat (!!! (NTFTX - 1) ) */
    if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
    count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
-   /* TODO: add (count != NTFTX) check, see refresh_ipl() */
+   if (count != NTFTX) {
+      perrno("send_found: read_tfile() incomplete (%d/%d)", count, NTFTX);
+      exit(1);  /* send_found() runs in a forked child */
+   }
 
    /* build peerlist with Rplist (shuffled) */
    memset(plist, 0, sizeof(plist));

--- a/src/test/tfile-read-error.c
+++ b/src/test/tfile-read-error.c
@@ -1,0 +1,79 @@
+/**
+ * Unit test for F-23 (issue #99): read_tfile() must return 0 on
+ * error, not VERROR (==1), so that callers can distinguish "failed
+ * to open file" from "successfully read one trailer".
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "_assert.h"
+#include "tfile.h"
+#include "types.h"
+
+int main(void)
+{
+   BTRAILER bt;
+   word8 bnum_zero[8] = {0};
+   size_t n;
+
+   /* --- Case 1: read from a file that does not exist ---
+    * Before fix: returned VERROR (== 1), indistinguishable from a
+    * legitimate one-trailer read.
+    * After fix: returns 0, which callers that check != 1 or <= 0
+    * correctly identify as an error. */
+   (void) remove("nonexistent_tfile.dat");
+   n = read_tfile(&bt, bnum_zero, 1, "nonexistent_tfile.dat");
+   ASSERT_EQ_MSG(n, 0,
+      "read_tfile() on a missing file must return 0 (not VERROR=1)");
+
+   /* --- Case 2: short read (request more than the file contains) ---
+    * Write a tfile containing exactly one trailer, then ask for 3.
+    * Result: n == 1, which is both a legitimate partial read AND
+    * the old VERROR value. Errno differentiates (EMCM_EOF). */
+   {
+      FILE *fp = fopen("short_tfile.dat", "wb");
+      BTRAILER trailer;
+      memset(&trailer, 0, sizeof(trailer));
+      ASSERT_NE(fp, NULL);
+      if (fwrite(&trailer, sizeof(BTRAILER), 1, fp) != 1) {
+         fprintf(stderr, "fwrite failed\n");
+         fclose(fp);
+         return 1;
+      }
+      fclose(fp);
+   }
+   n = read_tfile(&bt, bnum_zero, 3, "short_tfile.dat");
+   ASSERT_EQ_MSG(n, 1,
+      "read_tfile() must return the actual record count on a partial read");
+   (void) remove("short_tfile.dat");
+
+   /* --- Case 3: seek past end (bnum beyond file) ---
+    * Tfile has 1 trailer (bnum 0); we ask to start reading at bnum 5.
+    * fseek succeeds (past-end is allowed), fread returns 0.
+    * Before fix: still returned 0 (the happy path), BUT fopen-failure
+    * also returned VERROR=1 which collided with the real "1 record"
+    * case elsewhere. Case 3 itself exercises the normal-path 0 return
+    * which was already correct. */
+   {
+      FILE *fp = fopen("tiny_tfile.dat", "wb");
+      BTRAILER trailer;
+      memset(&trailer, 0, sizeof(trailer));
+      ASSERT_NE(fp, NULL);
+      if (fwrite(&trailer, sizeof(BTRAILER), 1, fp) != 1) {
+         fclose(fp);
+         return 1;
+      }
+      fclose(fp);
+   }
+   {
+      word8 bnum_past[8] = { 5, 0, 0, 0, 0, 0, 0, 0 };
+      n = read_tfile(&bt, bnum_past, 1, "tiny_tfile.dat");
+   }
+   ASSERT_EQ_MSG(n, 0,
+      "read_tfile() past EOF must return 0");
+   (void) remove("tiny_tfile.dat");
+
+   printf("[PASS] tfile-read-error: all 3 cases behave correctly\n");
+   return 0;
+}

--- a/src/tfile.c
+++ b/src/tfile.c
@@ -275,9 +275,11 @@ void merkle_root(const word8 *hashlist, size_t count, word8 *root)
  * @param bnum Start block number to read from Tfile
  * @param count Number of trailers to read from Tfile
  * @param tfile Filename of Tfile to read from
- * @return (int) number of records read from Tfile, which may be less
- * than count if an error ocurrs; check errno for details
-*/
+ * @return (size_t) number of records read from Tfile; check errno for
+ * details when the return is less than @a count
+ * @retval 0 on error (fopen/fseek failure, or zero records read);
+ * errno is set by the failing call (or EMCM_EOF on short read)
+ */
 size_t read_tfile
    (void *buffer, const word8 bnum[8], size_t count, const char *tfile)
 {
@@ -285,9 +287,12 @@ size_t read_tfile
    size_t n = 0;
    FILE *fp;
 
-   /* open Tfile and read trailer from offset */
+   /* open Tfile and read trailer from offset. Return 0 on error --
+    * NOT VERROR (==1), because VERROR would be indistinguishable from
+    * "successfully read one trailer" for callers that check != 1 or
+    * <= 0. 0 is the unambiguous error signal for this size_t API. */
    fp = fopen(tfile, "rb");
-   if (fp == NULL) return VERROR;
+   if (fp == NULL) return 0;
    /* seek to read offset for bnum */
    put64(&offset, bnum);
    offset *= sizeof(BTRAILER);


### PR DESCRIPTION
## Summary
Closes #99 (F-23).

\`read_tfile()\` returns \`size_t\` but previously returned \`VERROR\` (==1) on \`fopen()\` failure. \`1\` is also a valid count for \"one trailer read successfully.\" Callers that check \`!= 1\` or \`<= 0\` silently treated the error as success and proceeded with uninitialized buffer data on consensus-critical paths (\`ng_val\`, \`contention\`, \`send_found\`).

This change returns \`0\` on error. All existing callers already check \`!= 1\`, \`<= 0\`, or \`!= NTFTX\`, which correctly detect \`0\`.

Also wires up the pre-existing TODO in \`send_found()\` to check \`count != NTFTX\` and exit the forked child on incomplete read.

## Test plan
- [x] Unit test \`src/test/tfile-read-error.c\` covers three cases: missing file (returns 0), partial read (returns actual count), seek past EOF (returns 0). Validated to fail with pre-fix code and pass with post-fix.
- [x] Full build clean under \`-Wall -Werror -Wextra -Wpedantic\`.
- [x] Live mainnet sync from genesis through 600+ blocks with trace instrumentation to confirm no regression on happy path (\`read_tfile\` callers exercised via \`refresh_ipl\`, \`send_found\`, and OP_GET_TFILE service).