### PR TITLE
fix(network): close socket on every exit path in get_hash() (F-31, #117)

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -795,28 +795,31 @@ int get_hash(NODE *np, word32 ip, void *bnum, void *blockhash)
       put64(tx->blocknum, tx->cblock);
    } else put64(tx->blocknum, bnum);
 
-   /* perform OP_HASH request and receive -- close socket */
+   /* perform OP_HASH request and receive */
    pdebug("%s sending OP_HASH...", np->id);
    ecode = send_op(np, OP_HASH);
-   if (ecode != VEOK) return ecode;
+   if (ecode != VEOK) goto CLEANUP;
    ecode = recv_tx(np, STD_TIMEOUT);
-   if (ecode != VEOK) return ecode;
+   if (ecode != VEOK) goto CLEANUP;
 
-   /* cleanup -- check response */
-   sock_close(np->sd);
-   np->sd = INVALID_SOCKET;
+   /* check response */
    if (get16(tx->opcode) != OP_HASH) {
       pdebug("%s unexpected opcode...", np->id);
-      return VERROR;
-   } else if (get16(tx->len) != HASHLEN) {
+      ecode = VERROR;
+      goto CLEANUP;
+   }
+   if (get16(tx->len) != HASHLEN) {
       pdebug("%s unexpected len...", np->id);
-      return VERROR;
+      ecode = VERROR;
+      goto CLEANUP;
    }
    /* pass blockhash on success, if not NULL */
    if (blockhash) memcpy(blockhash, tx->buffer, HASHLEN);
 
-   /* success */
-   return VEOK;
+CLEANUP:
+   sock_close(np->sd);
+   np->sd = INVALID_SOCKET;
+   return ecode;
 }  /* end get_hash() */
 
 /**


### PR DESCRIPTION
## Summary
Closes #117 (F-31).

\`get_hash()\` leaked \`np->sd\` on \`send_op()\` or \`recv_tx()\` failure — both early returns skipped \`sock_close()\`. Under repeated peer probing failures (common with unreachable or misbehaving peers) this exhausts the process fd limit and prevents new outbound connections.

Restructured with a single \`CLEANUP\` label so every exit path (success, I/O failure, malformed response) closes the socket before returning. Matches the \`DROP_CLEANUP\` / \`ERROR_CLEANUP\` idiom used elsewhere in the codebase.

## Test plan
- [x] Full build clean under \`-Wall -Werror -Wextra -Wpedantic\`.
- [x] Reviewed all three callers (\`mochimo.c:434\`, \`mochimo.c:463\`, \`test/network-get-hash.c\`); none read \`np->sd\` after the call.