### PR TITLE
Promote audit fixes F-23, F-31, F-32 to master

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -795,28 +795,31 @@ int get_hash(NODE *np, word32 ip, void *bnum, void *blockhash)
       put64(tx->blocknum, tx->cblock);
    } else put64(tx->blocknum, bnum);
 
-   /* perform OP_HASH request and receive -- close socket */
+   /* perform OP_HASH request and receive */
    pdebug("%s sending OP_HASH...", np->id);
    ecode = send_op(np, OP_HASH);
-   if (ecode != VEOK) return ecode;
+   if (ecode != VEOK) goto CLEANUP;
    ecode = recv_tx(np, STD_TIMEOUT);
-   if (ecode != VEOK) return ecode;
+   if (ecode != VEOK) goto CLEANUP;
 
-   /* cleanup -- check response */
-   sock_close(np->sd);
-   np->sd = INVALID_SOCKET;
+   /* check response */
    if (get16(tx->opcode) != OP_HASH) {
       pdebug("%s unexpected opcode...", np->id);
-      return VERROR;
-   } else if (get16(tx->len) != HASHLEN) {
+      ecode = VERROR;
+      goto CLEANUP;
+   }
+   if (get16(tx->len) != HASHLEN) {
       pdebug("%s unexpected len...", np->id);
-      return VERROR;
+      ecode = VERROR;
+      goto CLEANUP;
    }
    /* pass blockhash on success, if not NULL */
    if (blockhash) memcpy(blockhash, tx->buffer, HASHLEN);
 
-   /* success */
-   return VEOK;
+CLEANUP:
+   sock_close(np->sd);
+   np->sd = INVALID_SOCKET;
+   return ecode;
 }  /* end get_hash() */
 
 /**

--- a/src/network.c
+++ b/src/network.c
@@ -602,7 +602,10 @@ bad:
    /* get proof from tfile.dat (!!! (NTFTX - 1) ) */
    if (sub64(Cblocknum, CL64_32(NTFTX - 1), bnum)) memset(bnum, 0, 8);
    count = read_tfile(tx.buffer, bnum, NTFTX, "tfile.dat");
-   /* TODO: add (count != NTFTX) check, see refresh_ipl() */
+   if (count != NTFTX) {
+      perrno("send_found: read_tfile() incomplete (%d/%d)", count, NTFTX);
+      exit(1);  /* send_found() runs in a forked child */
+   }
 
    /* build peerlist with Rplist (shuffled) */
    memset(plist, 0, sizeof(plist));

--- a/src/sync.c
+++ b/src/sync.c
@@ -88,13 +88,15 @@ int reset_chain(void)
 /**
  * Catch up by getting blocks from peers in plist[count].
  * Returns VEOK if updates made, else b_update() error code. */
-int catchup(word32 plist[], word32 count)
+int catchup(word32 plist[], word32 count_in)
 {
    void (*SIGTERM_old)(int);
    void (*SIGINT_old)(int);
    FILENAME fname_dl = {0};
    FILENAME fname = {0};
    word8 bnum[8];
+   /* volatile: while-loop reads below are outside OMP_CRITICAL_ */
+   volatile word32 count = count_in;
    /* thread-local working state (made private via the OMP private() clause
     * below; assigned inside the parallel region since OMP private does
     * not initialize) */

--- a/src/test/tfile-read-error.c
+++ b/src/test/tfile-read-error.c
@@ -1,0 +1,79 @@
+/**
+ * Unit test for F-23 (issue #99): read_tfile() must return 0 on
+ * error, not VERROR (==1), so that callers can distinguish "failed
+ * to open file" from "successfully read one trailer".
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "_assert.h"
+#include "tfile.h"
+#include "types.h"
+
+int main(void)
+{
+   BTRAILER bt;
+   word8 bnum_zero[8] = {0};
+   size_t n;
+
+   /* --- Case 1: read from a file that does not exist ---
+    * Before fix: returned VERROR (== 1), indistinguishable from a
+    * legitimate one-trailer read.
+    * After fix: returns 0, which callers that check != 1 or <= 0
+    * correctly identify as an error. */
+   (void) remove("nonexistent_tfile.dat");
+   n = read_tfile(&bt, bnum_zero, 1, "nonexistent_tfile.dat");
+   ASSERT_EQ_MSG(n, 0,
+      "read_tfile() on a missing file must return 0 (not VERROR=1)");
+
+   /* --- Case 2: short read (request more than the file contains) ---
+    * Write a tfile containing exactly one trailer, then ask for 3.
+    * Result: n == 1, which is both a legitimate partial read AND
+    * the old VERROR value. Errno differentiates (EMCM_EOF). */
+   {
+      FILE *fp = fopen("short_tfile.dat", "wb");
+      BTRAILER trailer;
+      memset(&trailer, 0, sizeof(trailer));
+      ASSERT_NE(fp, NULL);
+      if (fwrite(&trailer, sizeof(BTRAILER), 1, fp) != 1) {
+         fprintf(stderr, "fwrite failed\n");
+         fclose(fp);
+         return 1;
+      }
+      fclose(fp);
+   }
+   n = read_tfile(&bt, bnum_zero, 3, "short_tfile.dat");
+   ASSERT_EQ_MSG(n, 1,
+      "read_tfile() must return the actual record count on a partial read");
+   (void) remove("short_tfile.dat");
+
+   /* --- Case 3: seek past end (bnum beyond file) ---
+    * Tfile has 1 trailer (bnum 0); we ask to start reading at bnum 5.
+    * fseek succeeds (past-end is allowed), fread returns 0.
+    * Before fix: still returned 0 (the happy path), BUT fopen-failure
+    * also returned VERROR=1 which collided with the real "1 record"
+    * case elsewhere. Case 3 itself exercises the normal-path 0 return
+    * which was already correct. */
+   {
+      FILE *fp = fopen("tiny_tfile.dat", "wb");
+      BTRAILER trailer;
+      memset(&trailer, 0, sizeof(trailer));
+      ASSERT_NE(fp, NULL);
+      if (fwrite(&trailer, sizeof(BTRAILER), 1, fp) != 1) {
+         fclose(fp);
+         return 1;
+      }
+      fclose(fp);
+   }
+   {
+      word8 bnum_past[8] = { 5, 0, 0, 0, 0, 0, 0, 0 };
+      n = read_tfile(&bt, bnum_past, 1, "tiny_tfile.dat");
+   }
+   ASSERT_EQ_MSG(n, 0,
+      "read_tfile() past EOF must return 0");
+   (void) remove("tiny_tfile.dat");
+
+   printf("[PASS] tfile-read-error: all 3 cases behave correctly\n");
+   return 0;
+}

--- a/src/tfile.c
+++ b/src/tfile.c
@@ -275,9 +275,11 @@ void merkle_root(const word8 *hashlist, size_t count, word8 *root)
  * @param bnum Start block number to read from Tfile
  * @param count Number of trailers to read from Tfile
  * @param tfile Filename of Tfile to read from
- * @return (int) number of records read from Tfile, which may be less
- * than count if an error ocurrs; check errno for details
-*/
+ * @return (size_t) number of records read from Tfile; check errno for
+ * details when the return is less than @a count
+ * @retval 0 on error (fopen/fseek failure, or zero records read);
+ * errno is set by the failing call (or EMCM_EOF on short read)
+ */
 size_t read_tfile
    (void *buffer, const word8 bnum[8], size_t count, const char *tfile)
 {
@@ -285,9 +287,12 @@ size_t read_tfile
    size_t n = 0;
    FILE *fp;
 
-   /* open Tfile and read trailer from offset */
+   /* open Tfile and read trailer from offset. Return 0 on error --
+    * NOT VERROR (==1), because VERROR would be indistinguishable from
+    * "successfully read one trailer" for callers that check != 1 or
+    * <= 0. 0 is the unambiguous error signal for this size_t API. */
    fp = fopen(tfile, "rb");
-   if (fp == NULL) return VERROR;
+   if (fp == NULL) return 0;
    /* seek to read offset for bnum */
    put64(&offset, bnum);
    offset *= sizeof(BTRAILER);


### PR DESCRIPTION
Promotes three audit remediations from \`audit-fixes\` to \`master\`.

## Contents
- **F-23 / #99 / #158** — \`fix(tfile): return 0 on error from read_tfile() to disambiguate from 1-record read\`
  - \`read_tfile()\` now returns \`0\` on \`fopen()\` failure instead of \`VERROR\` (==1), which was indistinguishable from a legitimate single-trailer read.
  - Wired up the pre-existing TODO in \`send_found()\` to check \`count != NTFTX\`.
  - Unit test added: \`src/test/tfile-read-error.c\`.
- **F-31 / #117 / #159** — \`fix(network): close socket on every exit path in get_hash()\`
  - Restructured with a single \`CLEANUP:\` label so \`sock_close()\` runs on every exit path (was leaking \`np->sd\` on \`send_op\` / \`recv_tx\` failure).
- **F-32 / #112 / #160** — \`fix(sync): close data race on catchup() count read via volatile shadow\`
  - Local \`volatile word32 count = count_in\` shadow closes the race between the unsynchronized reader and the \`OMP_CRITICAL_\`-guarded writers. Underflow claim analyzed and determined not reachable (see #112 comment).

## Test plan
- [x] Per-PR test plans executed (build clean, unit tests pass, live sync validation where applicable).
- [x] Full build clean under \`-Wall -Werror -Wextra -Wpedantic -fopenmp\`.
- [x] No consensus-path behavioral changes; all three are correctness fixes on error/race paths.