### PR TITLE
ci(release): bump runner to ubuntu-22.04 (ubuntu-20.04 retired)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,11 +11,11 @@ defaults:
 
 jobs:
   miner:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup CUDA 12.8
-        run: | # CUDA 12.8 on Ubuntu-20.04 for NVIDIA 570.86.10 (Blackwell)
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+        run: | # CUDA 12.8 on Ubuntu-22.04 for NVIDIA 570.86.10 (Blackwell)
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
           sudo apt-get -y install cuda-toolkit-12-8


### PR DESCRIPTION
## Problem

The \`release\` workflow queues on \`runs-on: ubuntu-20.04\`, which was retired from GitHub-hosted runners in April 2025. As a result, the \`v3.1.0-beta\` release build ([run 24613049633](https://github.com/mochimodev/mochimo/actions/runs/24613049633)) has been sitting in \`queued\` state since it was created and will never pick up a runner.

## Fix

- \`runs-on: ubuntu-20.04\` → \`ubuntu-22.04\`
- NVIDIA apt repo path \`ubuntu2004\` → \`ubuntu2204\` to match

## Test plan
- [ ] After merge, manually trigger the workflow against \`v3.1.0-beta\` via \`gh workflow run release.yaml --ref v3.1.0-beta\` (or the \`workflow_dispatch\` button) and verify the CUDA install + \`make miner\` build + artifact upload succeed.
- [ ] Confirm the \`mcmminer-v3.1.0-beta.ubuntu.cuda-12.8-570.86.10.tar.gz\` asset lands on the release page.

## Follow-up

If we want future releases to be tied to a specific LTS more deliberately, we can pin \`ubuntu-22.04\` explicitly (as done here) or move to \`ubuntu-24.04\` — either works for CUDA 12.8; 22.04 is the closer compatibility hop from 20.04.